### PR TITLE
Purge out the requirement to use sudo

### DIFF
--- a/docs/source/fontpatching.rst
+++ b/docs/source/fontpatching.rst
@@ -65,7 +65,7 @@ Linux
 
 4. Update your font cache::
 
-       $ sudo fc-cache -vf
+       $ fc-cache -vf ~/.fonts
 
    If you're using vim in a terminal you may need to close all open terminal 
    windows after updating the font cache.


### PR DESCRIPTION
There is no need in regenerating font cache in _all_ directories. 
Make documentation suggest to regenerate just `~/.fonts` cache 
which actually changed.
