### PR TITLE
Purge out :echoe

### DIFF
--- a/powerline/ext/vim/powerline.vim
+++ b/powerline/ext/vim/powerline.vim
@@ -1,5 +1,7 @@
 if ! has('python')
-	echoe 'You need vim compiled with Python 2 support for Powerline to work. Please consult the documentation for more details.'
+	echohl ErrorMsg
+	echomsg 'You need vim compiled with Python 2 support for Powerline to work. Please consult the documentation for more details.'
+	echhl None
 	finish
 endif
 


### PR DESCRIPTION
`:echoe` is unstable: unless it is already in `:try`…`:catch` block
you never know for sure whether or not it will break execution.
Thus the only valid use for `:echoe` is

```
try
    echoe 'Msg'
endtry
```

: rough equivalent to `:throw` (throws, but with different message).
As this is probably not the thing you want to do
I changed it to use `:echomsg`.
