### PR TITLE
Changed code to use vim_get_func('fnameescape').

### DIFF
--- a/powerline/ext/vim/__init__.py
+++ b/powerline/ext/vim/__init__.py
@@ -4,5 +4,8 @@
 def source_plugin():
 	import os
 	import vim
+	from bindings import vim_get_func
 
-	vim.command('source ' + vim.eval('fnameescape("' + os.path.join(os.path.abspath(os.path.dirname(__file__)), 'powerline.vim') + '")'))
+	fnameescape = vim_get_func('fnameescape')
+
+	vim.command('source ' + fnameescape(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'powerline.vim')))


### PR DESCRIPTION
Previous version had problems with paths containing backslashes and/or double 
quotes.
