### PR TITLE
“pl” is too short name not to be likely claimed by anybody else

### DIFF
--- a/powerline/ext/vim/powerline.vim
+++ b/powerline/ext/vim/powerline.vim
@@ -1,18 +1,18 @@
-python import uuid, vim
+python import uuid
 python from powerline.core import Powerline
-python pl = Powerline('vim')
+python powerline = Powerline('vim')
 
 if exists('*pyeval')
 	let s:pyeval = function('pyeval')
 else
-	python import json
+	python import json, vim
 	function! s:pyeval(e)
 		python vim.command('return ' + json.dumps(eval(vim.eval('a:e'))))
 	endfunction
 endif
 
 function! Powerline(winnr, current)
-	return s:pyeval('pl.renderer.render('. a:winnr .', '. a:current .')')
+	return s:pyeval('powerline.renderer.render('. a:winnr .', '. a:current .')')
 endfunction
 
 function! s:UpdateWindows()


### PR DESCRIPTION
Don’t put such names in global scope, it is completely possible that “pl” will 
be claimed by some other plugin as well. There is no local scope for each .vim 
file in vim-python interface.
