### PR TITLE
Recreate git.Repository() on each call

### DIFF
--- a/powerline/lib/vcs/git.py
+++ b/powerline/lib/vcs/git.py
@@ -8,7 +8,7 @@ try:
 			self.directory = directory
 
 		def _repo(self):
-			return git.Repository(directory)
+			return git.Repository(self.directory)
 
 		def status(self, path=None):
 			'''Return status of repository or file.


### PR DESCRIPTION
It appears that pygit2 has similar to mercurial’s issue with statuses (they are 
not updated) and needs to be regenerated on each call as well. Implies to index 
statuses only though, that is why I used to think pygit2 does not have this 
problem.
