### PR TITLE
Never use time.time() to measure time intervals

### DIFF
--- a/powerline/lib/memoize.py
+++ b/powerline/lib/memoize.py
@@ -20,7 +20,7 @@ class memoize(object):
 		for func in self._caches:
 			cache = {}
 			for key in self._caches[func]:
-				if (time.time() - self._caches[func][key][1]) < self._timeouts[func]:
+				if (time.clock() - self._caches[func][key][1]) < self._timeouts[func]:
 					cache[key] = self._caches[func][key]
 			self._caches[func] = cache
 
@@ -34,10 +34,10 @@ class memoize(object):
 			key = (args, tuple(kw))
 			try:
 				v = self.cache[key]
-				if (time.time() - v[1]) > self.timeout:
+				if (time.clock() - v[1]) > self.timeout:
 					raise KeyError
 			except KeyError:
-				v = self.cache[key] = f(*args, **kwargs), time.time()
+				v = self.cache[key] = f(*args, **kwargs), time.clock()
 			return v[0]
 		func.func_name = f.func_name
 


### PR DESCRIPTION
This function is to be used to get local time only: nobody can say whether ntpd 
won’t adjust it next second, ntpdate will shift it by a few centuries or any 
such thing. There is time.clock() for measuring time intervals.
