### PR TITLE
Added file persistence to memoize decorator

### DIFF
--- a/powerline/lib/memoize.py
+++ b/powerline/lib/memoize.py
@@ -1,4 +1,5 @@
 import cPickle as pickle
+import os
 import time
 
 
@@ -18,8 +19,8 @@ class memoize(object):
 
         def func(*args, **kwargs):
 
-            if self.filename:
-                with open(self.filename, 'rb') as fileobj:
+            if self.filename and os.path.exists(self.filename):
+                with open(self.filename, 'r+b') as fileobj:
                     try:
                         self.caches = pickle.load(fileobj)
                     except EOFError:


### PR DESCRIPTION
The memoize decorator that's used to cache segments doesn't work with tmux since the caching mechanism stores results in memory, which is erased after the script has been evaluated.

My solution adds a "filename" argument to the memoize decorator, which should contain an absolute path to a file that will hold the pickled cache. Might want to change this to always put the file in the tmpdir.
