### PR TITLE
Add better tmux examples

### DIFF
--- a/examples/tmux/pl.py
+++ b/examples/tmux/pl.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python2
-# -*- coding: utf-8 -*-
 '''Powerline tmux statusline example.
 
 Run with `tmux -f tmux.conf`.
 '''
-
+import argparse
 import os
 import sys
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from powerline.core import Powerline
 
-pl = Powerline('tmux')
-print(pl.renderer.render('n').encode('utf-8'))
+parser = argparse.ArgumentParser(description='powerline outputter')
+parser.add_argument('side', nargs='?', default='all',
+                    choices=('all', 'left', 'right'))
+parser.add_argument('--ext', default='tmux')
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    pl = Powerline(args.ext)
+    segments = pl.renderer.get_theme().get_segments()
+    if args.side != 'all':
+        segments = [s for s in segments if s['side'] == args.side]
+    print(pl.renderer.render('n', segments=segments).encode('utf-8'))

--- a/examples/tmux/tmux.conf
+++ b/examples/tmux/tmux.conf
@@ -2,4 +2,7 @@ set-option -g status on
 set-option -g status-interval 2
 set-option -g status-utf8 on
 set-option -g status-left-length 100
-set-option -g status-left "#(./pl.py)"
+set-option -g status-left "#(./pl.py left)"
+set-option -g status-right-length 100
+set-option -g status-right "#(./pl.py right)"
+set-option -g status-justify "centre"


### PR DESCRIPTION
The current tmux example script/configuration only allows Powerline to configure the left side. These changes make the example `pl.py` script able to output segments for both sides, as well as making the script slightly more extensible. I've used this script to get Powerline looking much like [tmux-powerline](https://github.com/erikw/tmux-powerline) (with a few custom segments).

![enhanced tmux config](https://f.cloud.github.com/assets/77758/57901/1cb245d6-5b5d-11e2-8ac1-1975b41e6918.png)
