### PR TITLE
Add Pathogen/Vundle support

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -114,7 +114,7 @@ to the plugin location.
 Add the following line to your ``vimrc``, where ``{path}`` is the path to 
 the main Powerline project directory::
 
-    source {path}/powerline/bindings/vim/source_plugin.vim
+    source {path}/powerline/bindings/vim/plugin/source_plugin.vim
 
 Terminal prompts
 ^^^^^^^^^^^^^^^^

--- a/powerline/bindings/vim/plugin/source_plugin.vim
+++ b/powerline/bindings/vim/plugin/source_plugin.vim
@@ -6,6 +6,6 @@ if ! has('python')
 endif
 
 python import sys, vim
-python sys.path.append(vim.eval('expand("<sfile>:h:h:h:h")'))
+python sys.path.append(vim.eval('expand("<sfile>:h:h:h:h:h")'))
 
-source <sfile>:h/powerline.vim
+source <sfile>:h:h/powerline.vim


### PR DESCRIPTION
This commit enables use of

``` viml
Bundle 'Lokaltog/powerline', {'rtp': 'powerline/bindings/vim/'}
```

, which would be more convenience for `Vundle` user.
