### PR TITLE
Fixed problems in mode segment

### DIFF
--- a/powerline/ext/vim/segments.py
+++ b/powerline/ext/vim/segments.py
@@ -20,10 +20,10 @@ vim_modes = {
 	'no': u'N·OPER',
 	'v': u'VISUAL',
 	'V': u'V·LINE',
-	'': u'V·BLCK',
+	'^V': u'V·BLCK',
 	's': u'SELECT',
 	'S': u'S·LINE',
-	'': u'S·BLCK',
+	'^S': u'S·BLCK',
 	'i': u'INSERT',
 	'R': u'REPLACE',
 	'Rv': u'V·RPLCE',
@@ -34,6 +34,11 @@ vim_modes = {
 	'rm': u'MORE',
 	'r?': u'CONFIRM',
 	'!': u'SHELL',
+}
+
+mode_translations = {
+	chr(ord('V')-0x40): '^V',
+	chr(ord('S')-0x40): '^S',
 }
 
 
@@ -47,11 +52,12 @@ def mode(override=None):
 		mode = mode({ 'n': 'NORM' })
 	'''
 	mode = vim_funcs['mode']()
+	mode = mode_translations.get(mode, mode)
 	if not override:
 		return vim_modes[mode]
 	try:
 		return override[mode]
-	except IndexError:
+	except KeyError:
 		return vim_modes[mode]
 
 


### PR DESCRIPTION
- It was impossible to configure visual block and select block mode strings:
  JSON strings can contain neither raw control characters nor escape sequences 
  for them
- It was impossible to override only some of the strings:
  missing key generates KeyError exception, not IndexError
