### PR TITLE
Add the file_size segment

### DIFF
--- a/powerline/segments/vim.py
+++ b/powerline/segments/vim.py
@@ -97,6 +97,28 @@ def file_name(display_no_file=False, no_file_text='[No file]'):
 	return file_name.decode('utf-8')
 
 
+def _to_human(size, precision=2):
+	SUFFIXES = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
+	suffix = 0
+	while size >= 1024:
+		suffix += 1
+		size = size / 1024.0
+	if suffix == 0:
+		precision = 0
+	return u'%.*f %s' % (precision, size, SUFFIXES[suffix])
+
+
+def file_size():
+	'''Return file size.
+
+	Return None for unknown file size.
+	'''
+	if file_name() is None:
+		return None
+	file_size = vim_funcs['getfsize'](file_name())
+	return _to_human(file_size)
+
+
 def file_format():
 	'''Return file format (i.e. line ending type).
 


### PR DESCRIPTION
Added the following functions to segments/vim.py:
- file_size();
- _to_human(size[, precision]).

The first one retrieves the file size, the second one is an helper function to format the size as a human readable string.

---

I think this is a basic segment (probably more informative than the file format one, sometimes).
Obviously the segment should be added in the color scheme and in the theme config file for it to be visible.
