### PR TITLE
Replace old line number character

### DIFF
--- a/powerline/config_files/themes/vim/help.json
+++ b/powerline/config_files/themes/vim/help.json
@@ -20,7 +20,7 @@
 			},
 			{
 				"type": "string",
-				"contents": "⭡ ",
+				"contents": " ",
 				"highlight_group": ["line_current_symbol", "line_current"]
 			},
 			{


### PR DESCRIPTION
themes/vim/help.json still used the line number character from
vim-powerline.
