### PR TITLE
Remove PERCENT_PLACEHOLDER from vim renderer

### DIFF
--- a/powerline/config_files/themes/vim/default.json
+++ b/powerline/config_files/themes/vim/default.json
@@ -69,7 +69,7 @@
 				"name": "line_percent",
 				"args": { "gradient": true },
 				"priority": 30,
-				"after": "",
+				"after": "%%",
 				"rjust": 4
 			},
 			{

--- a/powerline/config_files/themes/vim/help.json
+++ b/powerline/config_files/themes/vim/help.json
@@ -15,7 +15,7 @@
 				"name": "line_percent",
 				"args": { "gradient": true },
 				"priority": 30,
-				"after": "",
+				"after": "%%",
 				"rjust": 4
 			},
 			{

--- a/powerline/renderers/vim.py
+++ b/powerline/renderers/vim.py
@@ -15,8 +15,6 @@ vim_setwinvar = vim_get_func('setwinvar')
 
 class VimRenderer(Renderer):
 	'''Powerline vim segment renderer.'''
-	PERCENT_PLACEHOLDER = u''
-
 	def __init__(self, *args, **kwargs):
 		super(VimRenderer, self).__init__(*args, **kwargs)
 		self.hl_groups = {}
@@ -25,8 +23,7 @@ class VimRenderer(Renderer):
 	def render(self, winnr, current):
 		'''Render all segments.
 
-		This method handles replacing of the percent placeholder for vim
-		statuslines, and it caches segment contents which are retrieved and
+    This method caches segment contents which are retrieved and
 		used in non-current windows.
 		'''
 		window_id = vim_getwinvar(winnr, 'window_id')
@@ -40,7 +37,6 @@ class VimRenderer(Renderer):
 			mode = 'nc'
 			theme, segments = self.window_cache.get(window_id, (None, None))
 		statusline = super(VimRenderer, self).render(mode, winwidth, theme, segments)
-		statusline = statusline.replace(self.PERCENT_PLACEHOLDER, '%%')
 		return statusline
 
 	def hl(self, fg=None, bg=None, attr=None):


### PR DESCRIPTION
Instead of using some unicode character that might or might not be used,
just use "%%" instead of "%" in theme files.
This probably needs to be documented somewhere, however the old solution
needed an explanation anyway.
