### PR TITLE
fix uptime when using psutil

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -109,7 +109,8 @@ def uptime(format='{days:02d}d {hours:02d}h {minutes:02d}m'):
 	try:
 		import psutil
 		from datetime import datetime
-		seconds = (datetime.now() - datetime.fromtimestamp(psutil.BOOT_TIME)).seconds
+		import time
+		seconds = int(time.mktime(datetime.now().timetuple()) - psutil.BOOT_TIME)
 	except ImportError:
 		try:
 			with open('/proc/uptime', 'r') as f:


### PR DESCRIPTION
for some reason, the days was always zero in the uptime when utilizing psutil, so I made some modifications and days are now showing up for me.

Should have said psutil in commit message.
