### PR TITLE
Escape powerline output to avoid wrapping in console

### DIFF
--- a/powerline/bindings/bash/powerline.sh
+++ b/powerline/bindings/bash/powerline.sh
@@ -16,4 +16,4 @@ trap "_powerline_tmux_set_columns" SIGWINCH
 kill -SIGWINCH "$$"
 
 export PROMPT_COMMAND="_powerline_tmux_set_pwd"
-export PS1='$(powerline shell left --last_exit_code=$?)'
+export PS1='\[$(powerline shell left --last_exit_code=$?)\]'


### PR DESCRIPTION
Not sure if this is the best way but it is the only way I could get it to work. I use tmux and have a lot of smaller terminals which were behaving fairly ugly when using powerline due to it not escaping non-printing characters.
