### PR TITLE
Use escape_hl_* variables for prompts deriving from ShellRenderer

### DIFF
--- a/powerline/renderers/bash_prompt.py
+++ b/powerline/renderers/bash_prompt.py
@@ -5,13 +5,9 @@ from powerline.renderers.shell import ShellRenderer
 
 class BashPromptRenderer(ShellRenderer):
 	'''Powerline bash prompt segment renderer.'''
-	def hl(self, contents=None, fg=None, bg=None, attr=None):
-		'''Highlight a segment.
 
-		Returns the default ShellRenderer escape sequence with \[...\] wrapped
-		around it (required in bash prompts).
-		'''
-		return '\[' + super(BashPromptRenderer, self).hl(None, fg, bg, attr) + '\]' + (contents or u'')
+	escape_hl_start = '\['
+	escape_hl_end = '\]'
 
 	@staticmethod
 	def escape(string):

--- a/powerline/renderers/ipython.py
+++ b/powerline/renderers/ipython.py
@@ -5,5 +5,6 @@ from powerline.renderers.shell import ShellRenderer
 
 class IpythonRenderer(ShellRenderer):
 	'''Powerline ipython segment renderer.'''
-	def hl(self, *args, **kwargs):
-		return '\x01' + super(IpythonRenderer, self).hl(*args, **kwargs) + '\x02'
+
+	escape_hl_start = '\x01'
+	escape_hl_end = '\x02'

--- a/powerline/renderers/shell.py
+++ b/powerline/renderers/shell.py
@@ -5,6 +5,10 @@ from powerline.renderer import Renderer
 
 class ShellRenderer(Renderer):
 	'''Powerline shell segment renderer.'''
+
+	escape_hl_start = ''
+	escape_hl_end = ''
+
 	def hl(self, contents=None, fg=None, bg=None, attr=None):
 		'''Highlight a segment.
 
@@ -35,7 +39,8 @@ class ShellRenderer(Renderer):
 			else:
 				if attr & Renderer.ATTR_BOLD:
 					ansi += [1]
-		return '[{0}m'.format(';'.join(str(attr) for attr in ansi)) + (contents or u'')
+		return self.escape_hl_start + '[{0}m'.format(';'.join(str(attr) for attr in ansi)) + self.escape_hl_end + \
+				(contents or u'')
 
 	@staticmethod
 	def escape(string):

--- a/powerline/renderers/zsh_prompt.py
+++ b/powerline/renderers/zsh_prompt.py
@@ -5,13 +5,9 @@ from powerline.renderers.shell import ShellRenderer
 
 class ZshPromptRenderer(ShellRenderer):
 	'''Powerline zsh prompt segment renderer.'''
-	def hl(self, contents=None, fg=None, bg=None, attr=None):
-		'''Highlight a segment.
 
-		Returns the default ShellRenderer escape sequence with %{...%} wrapped
-		around it (required in zsh prompts).
-		'''
-		return '%{' + super(ZshPromptRenderer, self).hl(None, fg, bg, attr) + '%}' + (contents or u'')
+	escape_hl_start = '%{'
+	escape_hl_end = '%}'
 
 	@staticmethod
 	def escape(string):


### PR DESCRIPTION
This is faster then super() calls and also more convenient.
Fixes #142 just as well
