### PR TITLE
Remove non-current window caching

### DIFF
--- a/powerline/bindings/vim/__init__.py
+++ b/powerline/bindings/vim/__init__.py
@@ -46,3 +46,5 @@ except AttributeError:
 			return r
 
 	vim_get_func = VimFunc
+
+getbufvar = vim_get_func('getbufvar')

--- a/powerline/bindings/vim/plugin/powerline.vim
+++ b/powerline/bindings/vim/plugin/powerline.vim
@@ -36,7 +36,7 @@ catch
 		finish
 	endtry
 endtry
-exec s:powerline_pycmd 'powerline = Powerline("vim")'
+exec s:powerline_pycmd 'powerline = Powerline("vim", segment_info={})'
 
 if exists('*'. s:powerline_pyeval)
 	let s:pyeval = function(s:powerline_pyeval)

--- a/powerline/config_files/themes/vim/default.json
+++ b/powerline/config_files/themes/vim/default.json
@@ -87,11 +87,12 @@
 				"align": "r"
 			},
 			{
-				"name": "col_current",
+				"name": "virtcol_current",
 				"draw_divider": false,
 				"priority": 30,
 				"before": ":",
 				"width": 3,
+				"highlight_group": ["col_current"],
 				"align": "l"
 			}
 		]

--- a/powerline/lib/memoize.py
+++ b/powerline/lib/memoize.py
@@ -16,7 +16,7 @@ class memoize(object):
 		@wraps(func)
 		def decorated_function(*args, **kwargs):
 			if self.additional_key:
-				key = (func.__name__, args, tuple(kwargs.items()), self.additional_key())
+				key = (func.__name__, args, tuple(kwargs.items()), self.additional_key(*args, **kwargs))
 			else:
 				key = (func.__name__, args, tuple(kwargs.items()))
 			cached = self._cache.get(key, None)

--- a/powerline/matchers/vim.py
+++ b/powerline/matchers/vim.py
@@ -3,11 +3,14 @@
 from __future__ import absolute_import
 
 import vim
+import os
+from powerline.bindings.vim import getbufvar
 
 
-def help():
-	return bool(int(vim.eval('&buftype is# "help"')))
+def help(matcher_info):
+	return getbufvar(matcher_info['bufnr'], '&buftype') == 'help'
 
 
-def cmdwin():
-	return bool(int(vim.eval('bufname("%") is# "[Command Line]"')))
+def cmdwin(matcher_info):
+	name = matcher_info['buffer'].name
+	return name and os.path.basename(name) == '[Command Line]'

--- a/powerline/renderer.py
+++ b/powerline/renderer.py
@@ -16,9 +16,9 @@ class Renderer(object):
 			raise KeyError('There is already a local theme with given matcher')
 		self.local_themes[matcher] = theme
 
-	def get_theme(self):
+	def get_theme(self, matcher_info):
 		for matcher in self.local_themes.keys():
-			if matcher():
+			if matcher(matcher_info):
 				match = self.local_themes[matcher]
 				if 'config' in match:
 					match['theme'] = Theme(theme_config=match.pop('config'), **self.theme_kwargs)
@@ -26,7 +26,7 @@ class Renderer(object):
 		else:
 			return self.theme
 
-	def render(self, mode=None, width=None, theme=None, segments=None, side=None, output_raw=False):
+	def render(self, mode=None, width=None, side=None, output_raw=False, segment_info=None, matcher_info=None):
 		'''Render all segments.
 
 		When a width is provided, low-priority segments are dropped one at
@@ -35,8 +35,11 @@ class Renderer(object):
 		provided they will fill the remaining space until the desired width is
 		reached.
 		'''
-		theme = theme or self.get_theme()
-		segments = segments or theme.get_segments(side)
+		theme = self.get_theme(matcher_info)
+		segments = theme.get_segments(side)
+
+		if segment_info:
+			theme.segment_info.update(segment_info)
 
 		# Handle excluded/included segments for the current mode
 		segments = [segment for segment in segments\

--- a/powerline/theme.py
+++ b/powerline/theme.py
@@ -11,6 +11,11 @@ except NameError:
 	unicode = str
 
 
+def requires_segment_info(func):
+	func.requires_powerline_segment_info = True
+	return func
+
+
 class Theme(object):
 	def __init__(self, ext, colorscheme, theme_config, common_config, segment_info=None):
 		self.colorscheme = colorscheme


### PR DESCRIPTION
API changes done:
- memoize additional_key function now accepts all function arguments
- get_theme now receives matcher_info
- render now receives segment_info and matcher_info, but segments and themes 
  were removed
- due to very different ways of obtaining column information col_current 
  splitted back to col_current and virtcol_current. The former should be false 
  in case of horizontal scrollbind (when &scrollopt contains hor)
- added requires_segment_info decorator for convenience

Other changes:
- removed all vim function calls that were possible to remove
- removed direct vim.eval calls

Ref #202
