### PR TITLE
Ease E858/E860 errors debugging

### DIFF
--- a/docs/source/installation/troubleshooting-common.rst
+++ b/docs/source/installation/troubleshooting-common.rst
@@ -30,3 +30,17 @@ My vim statusline is hidden/only appears in split windows!
 ----------------------------------------------------------
 
 * Make sure that you have ``set laststatus=2`` in your :file:`vimrc`.
+
+I get E858/E860 error in vim (Eval did not return a valid python object)
+--------------------------------------------------------------------------
+
+* You need to make ``pyeval()`` display python stack trace. There is currently 
+  a patch for this, but it was not merged into main vim tree, thus you will have 
+  to use different approach: reproduce the error with
+
+    .. code-block:: sh
+
+       vim --cmd "let g:powerline_debugging_pyeval=1" ...
+
+  and then use the stack trace to search for existing issues or to create a new 
+  one.

--- a/powerline/bindings/vim/plugin/powerline.vim
+++ b/powerline/bindings/vim/plugin/powerline.vim
@@ -38,13 +38,13 @@ catch
 endtry
 exec s:powerline_pycmd 'powerline = Powerline("vim", segment_info={})'
 
-if exists('*'. s:powerline_pyeval)
+if !get(g:, 'powerline_debugging_pyeval') && exists('*'. s:powerline_pyeval)
 	let s:pyeval = function(s:powerline_pyeval)
 else
 	exec s:powerline_pycmd 'import json, vim'
-	function! s:pyeval(e)
-		exec s:powerline_pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
-	endfunction
+	exec "function! s:pyeval(e)\n".
+		\	s:powerline_pycmd." vim.command('return ' + json.dumps(eval(vim.eval('a:e'))))\n".
+		\"endfunction"
 endif
 
 function! Powerline(winnr, current)


### PR DESCRIPTION
Added an option that makes obtaining stack trace not require patching `powerline.vim` or vim itself.
