### PR TITLE
Handle non-existant CWDs gracefully

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -52,9 +52,17 @@ def cwd(dir_shorten_len=None, dir_limit_depth=None):
 	'''
 	import re
 	try:
-		cwd = os.getcwdu()
-	except AttributeError:
-		cwd = os.getcwd()
+		try:
+			cwd = os.getcwdu()
+		except AttributeError:
+			cwd = os.getcwd()
+	except OSError as e:
+		if e.errno == 2:
+			# user most probably deleted the directory
+			# this happens when removing files from Mercurial repos for example
+			cwd = "[not found]"
+		else:
+			raise
 	home = os.environ.get('HOME')
 	if home:
 		cwd = re.sub('^' + re.escape(home), '~', cwd, 1)


### PR DESCRIPTION
This fixes the scenario when user changes directory somewhere into a Mercurial repo, removes the last file there, Mercurial nukes the entire file and powerline spams exceptions.

Instead of spamming exceptions and causing confusion, this change makes powerline output [not found] as current working directory. I believe that this is strictly better, RFC though :-)

This is the exception that gets raised and is never handled:

```
Traceback (most recent call last):
  File "/home/mpreisle/.local/bin/powerline", line 37, in <module>
    rendered = powerline.renderer.render(width=args.width, side=args.side)
  File "/home/mpreisle/.local/lib/python2.7/site-packages/powerline/renderer.py", line 45, in render
    segments = [segment for segment in segments\
  File "/home/mpreisle/.local/lib/python2.7/site-packages/powerline/theme.py", line 66, in get_segments
    contents = segment['contents_func'](**segment['args'])
  File "/home/mpreisle/.local/lib/python2.7/site-packages/powerline/segments/common.py", line 55, in cwd
    cwd = os.getcwdu()
OSError: [Errno 2] No such file or directory
```
