### PR TITLE
Use oldlace for visual mode foreground in vim

### DIFF
--- a/powerline/config_files/colorschemes/vim/solarized.json
+++ b/powerline/config_files/colorschemes/vim/solarized.json
@@ -65,17 +65,17 @@
 		},
 		"v": {
 			"groups": {
-				"mode": { "fg": "beige", "bg": "orange", "attr": ["bold"] }
+				"mode": { "fg": "oldlace", "bg": "orange", "attr": ["bold"] }
 			}
 		},
 		"V": {
 			"groups": {
-				"mode": { "fg": "beige", "bg": "orange", "attr": ["bold"] }
+				"mode": { "fg": "oldlace", "bg": "orange", "attr": ["bold"] }
 			}
 		},
 		"R": {
 			"groups": {
-				"mode": { "fg": "beige", "bg": "red", "attr": ["bold"] }
+				"mode": { "fg": "oldlace", "bg": "red", "attr": ["bold"] }
 			}
 		}
 	}


### PR DESCRIPTION
This seems to be the color that was intended.  #261 is fixed by this.
