### PR TITLE
Vim – Terminal timeout tip/trick interferes with other mappings

### DIFF
--- a/docs/source/tipstricks.rst
+++ b/docs/source/tipstricks.rst
@@ -17,11 +17,10 @@ immediately:
 .. code-block:: vim
 
    if ! has('gui_running')
-       set ttimeoutlen=10
        augroup FastEscape
            autocmd!
-           au InsertEnter * set timeoutlen=0
-           au InsertLeave * set timeoutlen=1000
+           au InsertEnter * set ttimeoutlen=1
+           au InsertLeave * set ttimeoutlen=-1
        augroup END
    endif
 


### PR DESCRIPTION
The autocommand group on the “Tips & Tricks” page to _“Fix terminal timeout when pressing escape”_ ([found here](http://git.io/v_w_5Q)) causes some mappings not to work.

For example, these don't work when the snippet is included in my vimrc:

```
inoremap jk <Esc>
inoremap jj <Esc>
```

Cheers,
Matt
