### PR TITLE
Do not throw away python stack trace

### DIFF
--- a/powerline/bindings/vim/plugin/powerline.vim
+++ b/powerline/bindings/vim/plugin/powerline.vim
@@ -10,7 +10,7 @@ function! s:CriticalError(message)
 endfunction
 
 if ! has('python') && ! has('python3')
-	call s:CriticalError('You need vim compiled with Python 2.7 or 3.2+ support
+	call s:CriticalError('You need vim compiled with Python 2.7 or 3.3+ support
 		\ for Powerline to work. Please consult the documentation for more details.')
 	finish
 endif
@@ -33,7 +33,7 @@ catch
 		if !exists('s:launched')
 			call s:CriticalError('An error occured while importing the Powerline package.
 				\ This could be caused by an invalid sys.path setting, or by an incompatible
-				\ Python version (Powerline requires Python 2.7 or 3.2+ to work). Please consult
+				\ Python version (Powerline requires Python 2.7 or 3.3+ to work). Please consult
 				\ the troubleshooting section in the documentation for possible solutions.')
 			finish
 		endif


### PR DESCRIPTION
Errors when loading powerline fails are almost never giving any useful 
information for debugging.
