### PR TITLE
Fixed email_imap_alert: it no longer returns an integer too

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -483,7 +483,7 @@ def email_imap_alert(username, password, server='imap.gmail.com', port=993, fold
 		return None
 	return [{
 		'highlight_group': 'email_alert',
-		'contents': unread_count,
+		'contents': str(unread_count),
 		}]
 
 


### PR DESCRIPTION
Fixes #279
