### PR TITLE
Fixed unicode() input handling.

### DIFF
--- a/powerline/theme.py
+++ b/powerline/theme.py
@@ -15,7 +15,7 @@ def u(s):
 	if type(s) is unicode:
 		return s
 	else:
-		return unicode(s, 'utf-8')
+		return unicode(str(s), 'utf-8')
 
 
 def requires_segment_info(func):


### PR DESCRIPTION
For example we can get an integer from mail segment(a number of mails in the inbox). In this case unicode() fails with TypeError.
