### PR TITLE
TTF output and style preservation

### DIFF
--- a/font/fontpatcher.py
+++ b/font/fontpatcher.py
@@ -3,6 +3,7 @@
 
 import argparse
 import sys
+import re
 import os.path
 
 try:
@@ -41,7 +42,10 @@ class FontPatcher(object):
 			if self.rename_font:
 				target_font.familyname += ' for Powerline'
 				target_font.fullname += ' for Powerline'
-				target_font.fontname += 'ForPowerline'
+				fontname, style = re.match("^([^-]*)(?:(-.*))?$", target_font.fontname).groups()
+				target_font.fontname = fontname + 'ForPowerline'
+				if style is not None:
+					target_font.fontname += style
 				target_font.appendSFNTName('English (US)', 'Preferred Family', target_font.familyname)
 				target_font.appendSFNTName('English (US)', 'Compatible Full', target_font.fullname)
 


### PR DESCRIPTION
So, I tried using the Ubuntu Mono OTF fonts from [Lokaltog/powerline-fonts](/Lokaltog/powerline-fonts) but the look terrible.  I think hinting information or something is lost in the conversion.  So, I've modified the font patcher to output either OTF or TTF based on the input format.  As a bonus, it's also faster.

The second commit here fixes styles, which get broken by appending `ForPowerline` to fonts with style suffixes in the fontname, ie - `UbuntuMono-Bold`.  Instead of simply appending `ForPowerline`, which results in a style of `BoldForPowerline`, it inserts it before any style information, ie - `UbuntuMonoForPowerline-Bold`, which preserves the correct style of `Bold`.
