### PR TITLE
Add XDG_CONFIG_DIRS to config_paths for system-wide install

### DIFF
--- a/powerline/__init__.py
+++ b/powerline/__init__.py
@@ -77,8 +77,13 @@ class Powerline(object):
 		'''
 		config_home = os.environ.get('XDG_CONFIG_HOME', os.path.join(os.path.expanduser('~'), '.config'))
 		config_path = os.path.join(config_home, 'powerline')
+		config_paths = [config_path]
+		config_dirs = os.environ.get('XDG_CONFIG_DIRS', None)
+		if config_dirs is not None:
+			config_paths.extend([os.path.join(d, 'powerline') for d in config_dirs.split(':')])
 		plugin_path = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'config_files')
-		return [config_path, plugin_path]
+		config_paths.append(plugin_path)
+		return config_paths
 
 	def load_theme_config(self, name):
 		'''Get theme configuration.


### PR DESCRIPTION
As per title, add all dirs in `$XDG_CONFIG_DIRS` env to config_paths (ie - `/etc/xdg/powerline`).
