### PR TITLE
Make vim Visual Block mode orange in Solarized colourscheme.

### DIFF
--- a/powerline/config_files/colorschemes/vim/solarized.json
+++ b/powerline/config_files/colorschemes/vim/solarized.json
@@ -75,6 +75,11 @@
 				"mode": { "fg": "oldlace", "bg": "orange", "attr": ["bold"] }
 			}
 		},
+		"^V": {
+			"groups": {
+				"mode": { "fg": "oldlace", "bg": "orange", "attr": ["bold"] }
+			}
+		},
 		"R": {
 			"groups": {
 				"mode": { "fg": "oldlace", "bg": "red", "attr": ["bold"] }


### PR DESCRIPTION
This makes it consistent with the styles of the other visual modes. Reference issue #147.
