### PR TITLE
Use $PWD for cwd before attempting getcwd() .

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -78,7 +78,7 @@ def cwd(dir_shorten_len=None, dir_limit_depth=None):
 	Highlight groups used: ``cwd:current_folder`` or ``cwd``. It is recommended to define all highlight groups.
 	'''
 	import re
-	cwd = os.getenv('PWD')
+	cwd = os.environ.get('PWD')
 	if cwd is None:
 		try:
 			try:


### PR DESCRIPTION
os.getcwd() follows symlinks and hence is not the same path as
returned from $PWD, which is more commonly used in the shell
prompt.
