### PR TITLE
Threaded cpu load percent

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -572,7 +572,13 @@ try:
 					self.exception('Exception while calculating cpu_percent: {0}', str(e))
 
 		def render(self, cpu_percent, format='{0:.0f}%', **kwargs):
-			return format.format(cpu_percent)
+			if not cpu_percent:
+				return None
+			return [{
+				'contents': format.format(cpu_percent),
+				'gradient_level': cpu_percent,
+				'highlight_group': ['cpu_load_percent_gradient', 'cpu_load_percent'],
+			}]
 except ImportError:
 	def _get_bytes(interface):  # NOQA
 		with open('/sys/class/net/{interface}/statistics/rx_bytes'.format(interface=interface), 'rb') as file_obj:
@@ -618,6 +624,8 @@ Requires the ``psutil`` module.
 
 :param str format:
 	Output format. Accepts measured CPU load as the first argument.
+
+Highlight groups used: ``cpu_load_percent_gradient`` (gradient) or ``cpu_load_percent``.
 ''')
 
 

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -244,7 +244,16 @@ class TestCommon(TestCase):
 	def test_cpu_load_percent(self):
 		pl = Pl()
 		with replace_module_module(common, 'psutil', cpu_percent=lambda **kwargs: 52.3):
-			self.assertEqual(common.cpu_load_percent(pl=pl), '52%')
+			self.assertEqual(common.cpu_load_percent(pl=pl), [{
+				'contents': '52%',
+				'gradient_level': 52.3,
+				'highlight_group': ['cpu_load_percent_gradient', 'cpu_load_percent'],
+			}])
+			self.assertEqual(common.cpu_load_percent(pl=pl, format='{0:.1f}%'), [{
+				'contents': '52.3%',
+				'gradient_level': 52.3,
+				'highlight_group': ['cpu_load_percent_gradient', 'cpu_load_percent'],
+			}])
 
 	def test_network_load(self):
 		from time import sleep


### PR DESCRIPTION
Current state should be replaced for the following reasons:

`interval=0.5` means that it will block for 0.5 seconds which is bad. With 
             threading it blocks only the separate thread, and it does not hold 
             GIL (uses regular time.sleep to wait) in this case which is fine.

`interval=0.05` means that it will report almost random value.

`interval=None` means that (assuming psutil.cpu_percent is called only by this 
              segment) it will report CPU load percent measured between two 
              subsequent .cpu_load_percent calls or cpu_load_percent call and 
              module import. It is used for update method to get immediate 
              result in case update_first is True. Cannot be used not in separate thread because it is just as good as `interval=0.05` at returning random values in case interval is interval between `.render()` calls.
