### PR TITLE
fix grad_list index

### DIFF
--- a/powerline/colorscheme.py
+++ b/powerline/colorscheme.py
@@ -26,7 +26,8 @@ def pick_gradient_value(grad_list, gradient_level):
 
 	Note: gradient level is not checked for being inside [0, 100] interval.
 	'''
-	return grad_list[int(round(gradient_level * (len(grad_list) - 1) / 100))]
+	index = min(int(round(gradient_level * (len(grad_list) - 1) / 100)), len(grad_list) - 1)
+	return grad_list[index]
 
 
 def hl_iter(value):


### PR DESCRIPTION
If `gradient_level` goes above 100%, `pick_gradient_value()` cause `IndexError`.

ex. I usually have <50 unread email messages, and set `max_msgs => 50`. If I have >50 unread messages by accident, powerline shows strings `list index out of range`.
