### PR TITLE
Alter the priority of branch and line_percent segments

### DIFF
--- a/powerline/config_files/themes/vim/default.json
+++ b/powerline/config_files/themes/vim/default.json
@@ -28,7 +28,7 @@
 			{
 				"name": "branch",
 				"exclude_modes": ["nc"],
-				"priority": 60
+				"priority": 30
 			},
 			{
 				"name": "readonly_indicator",
@@ -66,21 +66,21 @@
 				"name": "file_format",
 				"draw_soft_divider": false,
 				"exclude_modes": ["nc"],
-				"priority": 50
+				"priority": 60
 			},
 			{
 				"name": "file_encoding",
 				"exclude_modes": ["nc"],
-				"priority": 50
+				"priority": 60
 			},
 			{
 				"name": "file_type",
 				"exclude_modes": ["nc"],
-				"priority": 50
+				"priority": 60
 			},
 			{
 				"name": "line_percent",
-				"priority": 30,
+				"priority": 50,
 				"width": 4,
 				"align": "r"
 			},
@@ -98,7 +98,7 @@
 			{
 				"name": "virtcol_current",
 				"draw_soft_divider": false,
-				"priority": 30,
+				"priority": 20,
 				"before": ":",
 				"width": 3,
 				"align": "l"


### PR DESCRIPTION
Unlike file_type and file_directory branch cannot be deduced from the filename 
(you normally know directory structure of the project) and contents of the file.

Unlike file_format and file_encoding which are normally configured once and then 
forgotten about knowing branch segment is necessary to separate commits.
