### PR TITLE
Segment include_modes lists are useless

### DIFF
--- a/powerline/renderer.py
+++ b/powerline/renderer.py
@@ -186,7 +186,7 @@ class Renderer(object):
 
 		# Handle excluded/included segments for the current mode
 		segments = [self._get_highlighting(segment, mode) for segment in segments
-			if mode not in segment['exclude_modes'] or (segment['include_modes'] and segment in segment['include_modes'])]
+			if mode not in segment['exclude_modes'] and (not segment['include_modes'] or mode in segment['include_modes'])]
 
 		segments = [segment for segment in self._render_segments(theme, segments)]
 


### PR DESCRIPTION
There are currently a couple of major issues with handling of the exclude_modes and include_modes lists for segments that prevent the latter list from working at all.

First, the results of checking the two lists are or'd together meaning that if a mode isn't in the exclude list the include list is never even checked.

Second, the check of the include list looks for the segment object in the list rather than looking for the mode identifier. That check could never succeed. 
