### PR TITLE
Add maildir segment

### DIFF
--- a/powerline/config_files/colorschemes/shell/default.json
+++ b/powerline/config_files/colorschemes/shell/default.json
@@ -12,6 +12,8 @@
 		"cwd:divider": { "fg": "gray7", "bg": "gray4" },
 		"hostname": { "fg": "brightyellow", "bg": "mediumorange" },
 		"exit_fail": { "fg": "white", "bg": "darkestred" },
-		"exit_success": { "fg": "white", "bg": "darkestgreen" }
+		"exit_success": { "fg": "white", "bg": "darkestgreen" },
+		"email_alert": { "fg": "white", "bg": "brightred", "attr": ["bold"] },
+		"email_alert_gradient": { "fg": "white", "bg": "yellow_orange_red", "attr": ["bold"] }
 	}
 }

--- a/powerline/config_files/colorschemes/shell/solarized.json
+++ b/powerline/config_files/colorschemes/shell/solarized.json
@@ -12,6 +12,8 @@
 		"cwd:divider":        { "fg": "gray61", "bg": "darkgreencopper" },
 		"hostname":           { "fg": "oldlace", "bg": "darkgreencopper" },
 		"exit_fail":          { "fg": "oldlace", "bg": "red" },
-		"exit_success":       { "fg": "oldlace", "bg": "green" }
+		"exit_success":       { "fg": "oldlace", "bg": "green" },
+		"email_alert":        { "fg": "white", "bg": "brightred", "attr": ["bold"] },
+		"email_alert_gradient": { "fg": "white", "bg": "yellow_orange_red", "attr": ["bold"] }
 	}
 }

--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -120,6 +120,18 @@ Highlight groups used: ``branch_clean``, ``branch_dirty``, ``branch``.
 
 
 @requires_segment_info
+def maildir(pl, segment_info, directory='~/Maildir/new', placeholder='M'):
+	directory = os.path.expandvars(os.path.expanduser(directory))
+	mail = os.listdir(directory)
+	if mail:
+		return [{
+			'contents': '{0}:{1}'.format(placeholder, len(mail)),
+			'highlight_group': 'email_alert',
+		}]
+	else:
+		return None
+
+@requires_segment_info
 def cwd(pl, segment_info, dir_shorten_len=None, dir_limit_depth=None, use_path_separator=False):
 	'''Return the current working directory.
 

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -331,6 +331,25 @@ class TestCommon(TestCase):
 		# TODO
 		pass
 
+	def test_maildir(self):
+		pl = Pl()
+		segment_info = {'getcwd': os.getcwd}
+		# No files in Maildir folder means no new mail.
+		with replace_attr(os, 'listdir', lambda path: []):
+			self.assertEqual(common.maildir(pl=pl, segment_info=segment_info, directory='/tmp/maildir'), None)
+		# One new message.
+		with replace_attr(os, 'listdir', lambda path: ['msg1']):
+			self.assertEqual(common.maildir(pl=pl, segment_info=segment_info, directory='/tmp/maildir'),
+					[{'contents': 'M:1', 'highlight_group': 'email_alert'}])
+		# A lot of new messages.
+		with replace_attr(os, 'listdir', lambda path: ['msg'] * 999):
+			self.assertEqual(common.maildir(pl=pl, segment_info=segment_info, directory='/tmp/maildir'),
+					[{'contents': 'M:999', 'highlight_group': 'email_alert'}])
+		# New message, using custom placeholder.
+		with replace_attr(os, 'listdir', lambda path: ['msg1']):
+			self.assertEqual(common.maildir(pl=pl, segment_info=segment_info, directory='/tmp/maildir', placeholder='EMAIL@A'),
+					[{'contents': 'EMAIL@A:1', 'highlight_group': 'email_alert'}])
+
 	def test_now_playing(self):
 		# TODO
 		pass


### PR DESCRIPTION
This is a first, very simple iteration, mainly meant to be used in the shell prompt and/or in the tmux status bar. It supports custom placeholders in front of the unread count, so that multiple segments can be instantiated for different mailboxes (common case: personal + work mailboxes, synced with offlineimap, and accessed locally through mutt).

![Screen Shot 2013-04-26 at 00 34 33](https://f.cloud.github.com/assets/387628/428255/e313e1da-ae00-11e2-8331-c29e3493d694.png)

Ref #152
