### PR TITLE
Use realpath() to allow powerline to be symlinked.

### DIFF
--- a/scripts/powerline
+++ b/scripts/powerline
@@ -8,7 +8,7 @@ try:
 	from powerline.shell import ShellPowerline, get_argparser
 except ImportError:
 	import os
-	sys.path.append(os.path.dirname(os.path.dirname( \
+	sys.path.append(os.path.dirname(os.path.dirname(
 		os.path.abspath(os.path.realpath(__file__)))))
 	from powerline.shell import ShellPowerline, get_argparser  # NOQA
 


### PR DESCRIPTION
Just a small change to allow one to symlink the powerline script and not throw ImportErrors.
