### PR TITLE
Segment to Print Environment Variables

### DIFF
--- a/powerline/config_files/colorschemes/shell/default.json
+++ b/powerline/config_files/colorschemes/shell/default.json
@@ -12,6 +12,7 @@
 		"cwd:divider": { "fg": "gray7", "bg": "gray4" },
 		"hostname": { "fg": "brightyellow", "bg": "mediumorange" },
 		"exit_fail": { "fg": "white", "bg": "darkestred" },
-		"exit_success": { "fg": "white", "bg": "darkestgreen" }
+		"exit_success": { "fg": "white", "bg": "darkestgreen" },
+		"environment": { "fg": "white", "bg": "darkestgreen" }
 	}
 }

--- a/powerline/config_files/colorschemes/shell/solarized.json
+++ b/powerline/config_files/colorschemes/shell/solarized.json
@@ -12,6 +12,7 @@
 		"cwd:divider":        { "fg": "gray61", "bg": "darkgreencopper" },
 		"hostname":           { "fg": "oldlace", "bg": "darkgreencopper" },
 		"exit_fail":          { "fg": "oldlace", "bg": "red" },
-		"exit_success":       { "fg": "oldlace", "bg": "green" }
+		"exit_success":       { "fg": "oldlace", "bg": "green" },
+		"environment":        { "fg": "oldlace", "bg": "green" }
 	}
 }

--- a/powerline/config_files/colorschemes/tmux/default.json
+++ b/powerline/config_files/colorschemes/tmux/default.json
@@ -19,6 +19,7 @@
 		"network_load": { "fg": "gray8", "bg": "gray0" },
 		"network_load_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" },
 		"system_load": { "fg": "gray8", "bg": "gray0" },
-		"system_load_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" }
+		"system_load_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" },
+		"environment": { "fg": "gray8", "bg": "gray0" }
 	}
 }

--- a/powerline/config_files/colorschemes/vim/default.json
+++ b/powerline/config_files/colorschemes/vim/default.json
@@ -28,7 +28,8 @@
 		"line_current_symbol": { "fg": "gray1", "bg": "gray10" },
 		"virtcol_current_gradient": { "fg": "dark_GREEN_Orange_red", "bg": "gray10" },
 		"col_current": { "fg": "gray6", "bg": "gray10" },
-		"modified_buffers": { "fg": "brightyellow", "bg": "gray2" }
+		"modified_buffers": { "fg": "brightyellow", "bg": "gray2" },
+		"environment": { "fg": "gray8", "bg": "gray2" }
 	},
 	"mode_translations": {
 		"nc": {

--- a/powerline/config_files/colorschemes/vim/solarized.json
+++ b/powerline/config_files/colorschemes/vim/solarized.json
@@ -27,7 +27,8 @@
 		"line_current":             { "fg": "gray13", "bg": "lightyellow", "attr": ["bold"] },
 		"line_current_symbol":      { "fg": "gray13", "bg": "lightyellow" },
 		"virtcol_current_gradient": { "fg": "GREEN_Orange_red", "bg": "gray10" },
-		"col_current":              { "fg": "azure4", "bg": "lightyellow" }
+		"col_current":              { "fg": "azure4", "bg": "lightyellow" },
+		"environment":              { "fg": "gray61", "bg": "royalblue5" }
 	},
 	"mode_translations": {
 		"nc": {

--- a/powerline/config_files/colorschemes/wm/default.json
+++ b/powerline/config_files/colorschemes/wm/default.json
@@ -20,6 +20,7 @@
 		"system_load": { "fg": "gray8", "bg": "gray0" },
 		"system_load_good": { "fg": "lightyellowgreen", "bg": "gray0" },
 		"system_load_bad": { "fg": "gold3", "bg": "gray0" },
-		"system_load_ugly": { "fg": "orangered", "bg": "gray0" }
+		"system_load_ugly": { "fg": "orangered", "bg": "gray0" },
+		"environment": { "fg": "gray8", "bg": "gray0" }
 	}
 }

--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -23,6 +23,16 @@ cpu_count = None
 
 
 @requires_segment_info
+def environment(pl, segment_info, variable=None):
+	'''Return the value of any defined environment variable
+
+	:param string variable:
+		The environment variable to return if found
+	'''
+	return segment_info['environ'].get(variable, None)
+
+
+@requires_segment_info
 def hostname(pl, segment_info, only_if_ssh=False, exclude_domain=False):
 	'''Return the current hostname.
 

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -327,6 +327,15 @@ class TestCommon(TestCase):
 			segment_info['environ'].pop('VIRTUAL_ENV')
 			self.assertEqual(common.virtualenv(pl=pl, segment_info=segment_info), None)
 
+	def test_environment(self):
+		pl = Pl()
+		variable = 'FOO';
+		value = 'bar';
+		with replace_env(variable, value) as segment_info:
+			self.assertEqual(common.environment(pl=pl, segment_info=segment_info, variable=variable), value)
+			segment_info['environ'].pop(variable)
+			self.assertEqual(common.environment(pl=pl, segment_info=segment_info, variable=variable), None)
+
 	def test_email_imap_alert(self):
 		# TODO
 		pass


### PR DESCRIPTION
- Added segment function to powerline.segments.common.
  - Added test to check return values.
  - Added default colorschemes for everything but iPython.

Ref #477
