### PR TITLE
fix documented path to fontpatcher.py

### DIFF
--- a/docs/source/fontpatching.rst
+++ b/docs/source/fontpatching.rst
@@ -42,7 +42,7 @@ Code point  Glyph  Description
 Usage
 =====
 
-The font patcher is located at :file:`powerline/fontpatcher/fontpatcher.py`.  
+The font patcher is located at :file:`powerline/font/fontpatcher.py`.  
 It requires Python 2.7 and FontForge compiled with Python bindings to work.
 
 Patched fonts are renamed by default (" for Powerline" is added to the font 


### PR DESCRIPTION
fontpatcher.py is in the `font` directory, not `fontpatcher` directory.
