### PR TITLE
Fix infinite add_watches loop with symbolic links

### DIFF
--- a/powerline/lib/tree_watcher.py
+++ b/powerline/lib/tree_watcher.py
@@ -50,6 +50,10 @@ class INotifyTreeWatcher(INotify):
 		''' Add watches for this directory and all its descendant directories,
 		recursively. '''
 		base = realpath(base)
+		# There may exist a link which leads to an endless
+		# add_watches loop or to maximum recursion depth exceeded
+		if not top_level and base in self.watched_dirs:
+			return
 		try:
 			is_dir = self.add_watch(base)
 		except OSError as e:


### PR DESCRIPTION
Added a check to ensure that add_watches doesn't run on the same folder over and over again. This occurs at least when circular symbolic links are present.

Fix #543
