### PR TITLE
Workaround Python import conflicts with sys.path inside Vim

### DIFF
--- a/powerline/bindings/vim/plugin/powerline.vim
+++ b/powerline/bindings/vim/plugin/powerline.vim
@@ -25,7 +25,7 @@ try
 				\  ."	".s:import_cmd."\n"
 				\  ."except ImportError:\n"
 				\  ."	import sys, vim\n"
-				\  ."	sys.path.append(vim.eval('expand(\"<sfile>:h:h:h:h:h\")'))\n"
+				\  ."	sys.path.insert(0, vim.eval('expand(\"<sfile>:h:h:h:h:h\")'))\n"
 				\  ."	".s:import_cmd
 	let s:launched = 1
 finally


### PR DESCRIPTION
After updating Vim to version 7.3.1163, Powerline refused to run its setup routine. 

`An error occurred while importing the Powerline package. This could be caused by an invalid sys.path setting, or by[...]`

Since my Powerline sources are not in any common Python package directory, loading depends on sys.path modification. Actually sys.path contains '_vim_path_' value. I don't know if it's new, but it seems to me that module lookup is not done inside subsequent items (directories).

`sys.path = ['/usr/lib64/python27.zip', '/usr/lib64/python2.7', '/usr/lib64/python2.7/plat-linux2', '/usr/lib64/python2.7/lib-tk', ..., '_vim_path_', '/home/covin/.vim/bundle/powerline']`

Prepending Powerline directory to sys.path fixes loading problem for me:

`sys.path = ['/home/covin/.vim/bundle/powerline', '/usr/lib64/python27.zip', ..., '_vim_path_']`
