### PR TITLE
Dont log inotify missing error when using branch coloring

### DIFF
--- a/powerline/lib/inotify.py
+++ b/powerline/lib/inotify.py
@@ -26,6 +26,8 @@ def load_inotify():
 			# if the one chosen by ctypes is compatible with the currently
 			# loaded one.
 			raise INotifyError('INotify not available on windows')
+		if sys.platform == 'darwin':
+			raise INotifyError('INotify not available on OS X')
 		import ctypes
 		if not hasattr(ctypes, 'c_ssize_t'):
 			raise INotifyError('You need python >= 2.7 to use inotify')

--- a/powerline/lib/tree_watcher.py
+++ b/powerline/lib/tree_watcher.py
@@ -162,7 +162,7 @@ class TreeWatcher(object):
 		try:
 			w = INotifyTreeWatcher(path, ignore_event=ignore_event)
 		except (INotifyError, DirTooLarge) as e:
-			if logger is not None:
+			if logger is not None and not isinstance(e, INotifyError):
 				logger.warn('Failed to watch path: {0} with error: {1}'.format(path, e))
 			w = DummyTreeWatcher(path)
 		self.watches[path] = w


### PR DESCRIPTION
The error message about inotify being missing when branch coloring is
enabled was being logged for every directory and for every invocation
of powerline in a shell, without powerline-daemon. Dont log it, since
the log is printed to stderr when using powerline in a shell without
powerline-daemon. Also improve the error message on OS X. Fixes #578
