### PR TITLE
Set different window name foreground based on activity and bell status.

### DIFF
--- a/powerline/bindings/tmux/powerline.conf
+++ b/powerline/bindings/tmux/powerline.conf
@@ -8,6 +8,11 @@ set -g status-left-length 20
 set -g status-left '#[fg=colour16,bg=colour254,bold] #S #[fg=colour254,bg=colour234,nobold]#(eval $POWERLINE_COMMAND tmux left)'
 set -g status-right '#(eval $POWERLINE_COMMAND tmux right -R pane_id=`tmux display -p "#D"`)'
 set -g status-right-length 150
-set -g window-status-format "#[fg=colour244,bg=colour234]#I #[fg=colour240] #[fg=colour249]#W "
+set -g window-status-format "#[fg=colour244,bg=colour234]#I #[fg=colour240] #[default]#W "
 set -g window-status-current-format "#[fg=colour234,bg=colour31]#[fg=colour117,bg=colour31] #I  #[fg=colour231,bold]#W #[fg=colour31,bg=colour234,nobold]"
+set-window-option -g window-status-fg colour249
+set-window-option -g window-status-activity-attr none
+set-window-option -g window-status-bell-attr none
+set-window-option -g window-status-activity-fg yellow
+set-window-option -g window-status-bell-fg red
 # vim: ft=tmux


### PR DESCRIPTION
Use `#[default]` to reset color settings on inactive window name, so it can be controlled by `*-fg` options.

Refs #248.

![screenshot on 2013-07-09 at 09 33 24](https://f.cloud.github.com/assets/35768/765702/e8dff902-e837-11e2-8183-91ef86c6407d.png)
