### PR TITLE
Fix #604

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # vim:fileencoding=utf-8:noet
-
+from __future__ import unicode_literals
 import os
 import sys
 
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
-	README = open(os.path.join(here, 'README.rst')).read()
+	README = open(os.path.join(here, 'README.rst'), 'rb').read().decode('utf-8')
 except IOError:
 	README = ''
 


### PR DESCRIPTION
Fixes running setup on python 3.x on linux system with their default encoding set to something other than utf-8.
