### PR TITLE
Fix UnicodeDecodeError for setup.py bdist_rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # vim:fileencoding=utf-8:noet
-from __future__ import unicode_literals
 import os
 import sys
 
@@ -20,7 +19,7 @@ setup(
 	description='The ultimate statusline/prompt utility.',
 	long_description=README,
 	classifiers=[],
-	author='Kim Silkebækken',
+	author=u'Kim Silkebækken',
 	author_email='kim.silkebaekken+vim@gmail.com',
 	url='https://github.com/Lokaltog/powerline',
 	scripts=[


### PR DESCRIPTION
Fixes #623

`python3.3 setup.py bdist_rpm` fails on Fedora 19 with or without this patch,
so someone should test if this works for Python3 or not. Nevertheless
`setup.py build` and `setup.py install` seem to work.
