### PR TITLE
Update OSX installation instructions

### DIFF
--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -25,6 +25,9 @@ Python package
 .. note:: You need to use the GitHub URI when installing Powerline! This 
    project is currently unavailable on the PyPI due to a naming conflict 
    with an unrelated project.
+   
+.. note:: If you installed Python via homebrew, you do not need to specify
+   the --user flag while installing Powerline
 
 Vim installation
 ----------------


### PR DESCRIPTION
If Python was installed via `brew` rather than `port`, the `--user` flag
causes installation errors as described in #631. Homebrew team
member @samueljohn mentions this in #552
