### PR TITLE
Handle gitfiles when retrieving branch name

### DIFF
--- a/powerline/lib/vcs/git.py
+++ b/powerline/lib/vcs/git.py
@@ -19,23 +19,22 @@ def branch_name_from_config_file(directory, config_file):
 		return m.group(1).decode('utf-8', 'replace')
 	return raw[:7]
 
+def git_directory(directory):
+	path = os.path.join(directory, '.git')
+	if os.path.isfile(path):
+		with open(path, 'rb') as f:
+			raw = f.read().partition(b':')[2].strip()
+			return os.path.abspath(os.path.join(directory, raw))
+	else:
+		return path
+
 def get_branch_name(base_dir):
-	head = os.path.join(base_dir, '.git', 'HEAD')
-	try:
-		return _get_branch_name(base_dir, head, branch_name_from_config_file)
-	except OSError as e:
-		if getattr(e, 'errno', None) == errno.ENOTDIR or getattr(e, 'winerror', None) == 3:
-			# We are in a submodule
-			return '(no branch)'
-		raise
+	head = os.path.join(git_directory(base_dir), 'HEAD')
+	return _get_branch_name(base_dir, head, branch_name_from_config_file)
 
 def do_status(directory, path, func):
 	if path:
-		gitd = os.path.join(directory, '.git')
-		if os.path.isfile(gitd):
-			with open(gitd, 'rb') as f:
-				raw = f.read().partition(b':')[2].strip()
-				gitd = os.path.abspath(os.path.join(directory, raw))
+		gitd = git_directory(directory)
 		# We need HEAD as without it using fugitive to commit causes the
 		# current file's status (and only the current file) to not be updated
 		# for some reason I cannot be bothered to figure out.


### PR DESCRIPTION
Move code to parse a .git file from the do_status method to a new method
shared with get_branch_name so that branch name can be retreived from
repositories which use a .git file.

Closes #634.
