### PR TITLE
Option to suppress error in python-less vim

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -455,6 +455,10 @@ Vim configuration can be overridden using the following options:
     directory which will be searched for configuration. When this option is 
     present, none of the other locations are searched.
 
+``g:powerline_no_python_error``
+    If this variable is set to a true value it will prevent Powerline from reporting 
+    an error when loaded in a copy of vim without the necessary Python support.
+
 Powerline script overrides
 --------------------------
 

--- a/powerline/bindings/vim/plugin/powerline.vim
+++ b/powerline/bindings/vim/plugin/powerline.vim
@@ -10,8 +10,10 @@ function! s:CriticalError(message)
 endfunction
 
 if ! has('python') && ! has('python3')
-	call s:CriticalError('You need vim compiled with Python 2.6+ or 3.2+ support
-		\ for Powerline to work. Please consult the documentation for more details.')
+	if !exists('g:powerline_no_python_error')
+		call s:CriticalError('You need vim compiled with Python 2.6+ or 3.2+ support
+			\ for Powerline to work. Please consult the documentation for more details.')
+	endif
 	finish
 endif
 


### PR DESCRIPTION
If the g:powerline_no_python_error variable is set don't issue an error
message even if vim doesn't have the required Python support.  This
allows a common set of configuration files to be used across systems
where some of the copies of vim don't meet the requirements.
