### PR TITLE
ignore trailing whitespace errors in .rst files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rst whitespace=-blank-at-eol


### PR DESCRIPTION
Use a .gitattributes file to tell git to not highlight trailing
whitespace as an error in .rst files when showing diffs.  A trailing
space is used on many lines in those files to indicate that the
paragraph continues onto the next line.
