### PR TITLE
Add "head" segment

### DIFF
--- a/powerline/lib/vcs/git.py
+++ b/powerline/lib/vcs/git.py
@@ -129,6 +129,9 @@ try:
 
 		def branch(self):
 			return get_branch_name(self.directory)
+
+		def head(self, path=None):
+			return git.Repository(self.directory).head.shorthand
 except ImportError:
 	from subprocess import Popen, PIPE
 
@@ -180,3 +183,9 @@ except ImportError:
 
 		def branch(self):
 			return get_branch_name(self.directory)
+
+		def head(self, path=None):
+			try:
+				return next(self._gitcmd(self.directory, 'rev-parse', '--short', 'HEAD'))
+			except StopIteration:
+				return None

--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -75,6 +75,26 @@ def branch(pl, segment_info, status_colors=False):
 
 
 @requires_segment_info
+def head(pl, segment_info):
+	'''Return the name of the current head object (i.e. the git sha1)
+
+	Highlight groups used: ``head`` or ``branch``.
+	'''
+	name = segment_info['getcwd']()
+	repo = guess(path=name)
+	if repo is not None:
+		head = repo.head()
+		branch = repo.branch()
+		if head == branch:
+			return None
+		else:
+			return [{
+				'contents': head,
+				'highlight_group': ['head', 'branch'],
+			}]
+
+
+@requires_segment_info
 def cwd(pl, segment_info, dir_shorten_len=None, dir_limit_depth=None, use_path_separator=False):
 	'''Return the current working directory.
 


### PR DESCRIPTION
Hi,

This is the first time I've used github's pull request thingy, hopefully I've got it right.

This adds a segment to display the abbreviated sha1 of the current HEAD. Currently its only implemented for git, I haven't looked at hg support yet and I don't know if it really maps to anything under svn. One thing that I haven't figured out is how to have the segment hide when in a detached HEAD state (currently you get the sha1 twice).
