### PR TITLE
Show Count of Attached Tmux Sessions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Segments
    segments/common
    segments/shell
    segments/vim
+   segments/tmux
 
 Indices and tables
 ==================

--- a/docs/source/segments/tmux.rst
+++ b/docs/source/segments/tmux.rst
@@ -1,0 +1,6 @@
+*************
+Tmux segments
+*************
+
+.. automodule:: powerline.segments.tmux
+   :members:

--- a/powerline/config_files/colorschemes/shell/default.json
+++ b/powerline/config_files/colorschemes/shell/default.json
@@ -17,7 +17,8 @@
 		"exit_fail": { "fg": "white", "bg": "darkestred" },
 		"exit_success": { "fg": "white", "bg": "darkestgreen" },
 		"environment": { "fg": "white", "bg": "darkestgreen" },
-		"mode": { "fg": "darkestgreen", "bg": "brightgreen", "attr": ["bold"] }
+		"mode": { "fg": "darkestgreen", "bg": "brightgreen", "attr": ["bold"] },
+		"attached_clients": { "fg": "white", "bg": "darkestgreen" }
 	},
 	"mode_translations": {
 		"vicmd": {

--- a/powerline/config_files/colorschemes/shell/solarized.json
+++ b/powerline/config_files/colorschemes/shell/solarized.json
@@ -17,7 +17,8 @@
 		"exit_fail":            { "fg": "oldlace", "bg": "red" },
 		"exit_success":         { "fg": "oldlace", "bg": "green" },
 		"environment":          { "fg": "oldlace", "bg": "green" },
-		"mode":                 { "fg": "oldlace", "bg": "green", "attr": ["bold"] }
+		"mode":                 { "fg": "oldlace", "bg": "green", "attr": ["bold"] },
+		"attached_clients":     { "fg": "oldlace", "bg": "green" }
 	},
 	"mode_translations": {
 		"vicmd": {

--- a/powerline/config_files/colorschemes/tmux/default.json
+++ b/powerline/config_files/colorschemes/tmux/default.json
@@ -23,6 +23,7 @@
 		"cpu_load_percent": { "fg": "gray8", "bg": "gray0" },
 		"cpu_load_percent_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" },
 		"environment": { "fg": "gray8", "bg": "gray0" },
+		"attached_clients": { "fg": "gray8", "bg": "gray0" },
 		"battery": { "fg": "gray8", "bg": "gray0" },
 		"battery_gradient": { "fg": "white_red", "bg": "gray0" },
 		"now_playing": { "fg": "gray10", "bg": "black" }

--- a/powerline/config_files/colorschemes/vim/default.json
+++ b/powerline/config_files/colorschemes/vim/default.json
@@ -34,6 +34,7 @@
 		"col_current":              { "fg": "gray6", "bg": "gray10" },
 		"modified_buffers":         { "fg": "brightyellow", "bg": "gray2" },
 		"environment":              { "fg": "gray8", "bg": "gray2" },
+		"attached_clients":         { "fg": "gray8", "bg": "gray2" },
 		"error":                    { "fg": "brightestred", "bg": "darkred", "attr": ["bold"] },
 		"warning":                  { "fg": "brightyellow", "bg": "darkorange", "attr": ["bold"] },
 		"current_tag":              { "fg": "gray9", "bg": "gray2" }

--- a/powerline/config_files/colorschemes/vim/solarized.json
+++ b/powerline/config_files/colorschemes/vim/solarized.json
@@ -33,6 +33,7 @@
 		"virtcol_current_gradient": { "fg": "GREEN_Orange_red", "bg": "lightyellow" },
 		"col_current":              { "fg": "azure4", "bg": "lightyellow" },
 		"environment":              { "fg": "gray61", "bg": "royalblue5" },
+		"attached_clients":         { "fg": "gray61", "bg": "royalblue5" },
 		"error":                    { "fg": "oldlace", "bg": "red", "attr": ["bold"] },
 		"warning":                  { "fg": "oldlace", "bg": "orange", "attr": ["bold"] },
 		"current_tag":              { "fg": "oldlace", "bg": "royalblue5", "attr": ["bold"] }

--- a/powerline/config_files/colorschemes/wm/default.json
+++ b/powerline/config_files/colorschemes/wm/default.json
@@ -21,6 +21,7 @@
 		"system_load_good": { "fg": "lightyellowgreen", "bg": "gray0" },
 		"system_load_bad": { "fg": "gold3", "bg": "gray0" },
 		"system_load_ugly": { "fg": "orangered", "bg": "gray0" },
-		"environment": { "fg": "gray8", "bg": "gray0" }
+		"environment": { "fg": "gray8", "bg": "gray0" },
+		"attached_clients": { "fg": "gray8", "bg": "gray0" }
 	}
 }

--- a/powerline/segments/tmux.py
+++ b/powerline/segments/tmux.py
@@ -1,0 +1,34 @@
+# vim:fileencoding=utf-8:noet
+
+import os
+from subprocess import Popen, PIPE
+
+
+def attached_clients(pl, minimum=1):
+	'''Return the number of tmux clients attached to the currently active session
+
+	:param int minimum:
+		The minimum number of attached clients that must be present for this segment to be visible
+	'''
+	try:
+		with open(os.devnull, "w") as devnull:
+			find_session_name = ["tmux", "list-panes", "-F", "#{session_name}"]
+			session_name_process = Popen(find_session_name, stdout=PIPE, stderr=devnull)
+			session_output, err = session_name_process.communicate()
+
+			if 0 == len(session_output):
+				return None
+
+			session_name = session_output.rstrip().split(os.linesep)[0]
+
+			find_clients = ["tmux", "list-clients", "-t", session_name]
+			attached_clients_process = Popen(find_clients, stdout=PIPE, stderr=devnull)
+			attached_clients_output, err = attached_clients_process.communicate()
+
+			attached_count = len(attached_clients_output.rstrip().split(os.linesep))
+
+	except Exception as e:
+		sys.stderr.write('Could not execute attached_clients: ({0})\n'.format(e))
+		return None
+
+	return None if attached_count < minimum else str(attached_count)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -41,6 +41,14 @@ def urllib_read(query_url):
 	else:
 		raise NotImplementedError
 
+class Process(object):
+	def __init__(self, output, err):
+		self.output = output
+		self.err = err
+
+	def communicate(self):
+		return self.output, self.err
+
 
 class ModuleReplace(object):
 	def __init__(self, name, new):

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -2,11 +2,11 @@
 
 from __future__ import unicode_literals
 
-from powerline.segments import shell, common
+from powerline.segments import shell, tmux, common
 import tests.vim as vim_module
 import sys
 import os
-from tests.lib import Args, urllib_read, replace_attr, new_module, replace_module_module, replace_env, Pl
+from tests.lib import Args, urllib_read, replace_attr, new_module, replace_module_module, replace_env, Pl, Process
 from tests import TestCase
 
 
@@ -144,6 +144,21 @@ class TestShell(TestCase):
 				'align': 'l',
 			},
 		])
+
+
+class TestTmux(TestCase):
+	def test_attached_clients(self):
+		def popen_mock(parameters, **kwargs):
+			if "list-panes" == parameters[1]:
+				return Process("session_name", "")
+			elif "list-clients" == parameters[1]:
+				clients = ["/dev/pts/2: 0 [191x51 xterm-256color] (utf8)", "/dev/pts/3: 0 [191x51 xterm-256color] (utf8)"]
+				return Process(os.linesep.join(clients), "")
+
+		pl = Pl()
+		with replace_attr(tmux, 'Popen', popen_mock):
+			self.assertEqual(tmux.attached_clients(pl=pl, ), "2")
+			self.assertEqual(tmux.attached_clients(pl=pl, minimum=3), None)
 
 
 class TestCommon(TestCase):


### PR DESCRIPTION
- This segment displays the number of attached tmux clients to the
  currently running session.
- The minimum argument is used to specify a threshold for when the
  segment should be visible.

Ref #661
