### PR TITLE
Fix git branch name sometimes getting stuck with inotify

### DIFF
--- a/powerline/lib/vcs/__init__.py
+++ b/powerline/lib/vcs/__init__.py
@@ -31,6 +31,15 @@ def file_watcher():
 		_file_watcher = create_file_watcher()
 	return _file_watcher
 
+_branch_watcher = None
+
+def branch_watcher():
+	global _branch_watcher
+	if _branch_watcher is None:
+		from powerline.lib.file_watcher import create_file_watcher
+		_branch_watcher = create_file_watcher()
+	return _branch_watcher
+
 branch_name_cache = {}
 branch_lock = Lock()
 file_status_lock = Lock()
@@ -39,7 +48,7 @@ def get_branch_name(directory, config_file, get_func):
 	global branch_name_cache
 	with branch_lock:
 		# Check if the repo directory was moved/deleted
-		fw = file_watcher()
+		fw = branch_watcher()
 		is_watched = fw.is_watched(directory)
 		try:
 			changed = fw(directory)


### PR DESCRIPTION
If you try to checkout the already current branch in git, git creates
HEAD.lock and renames it to HEAD. This causes the inode of HEAD to
change and so the inotify file watcher stops tracking HEAD.

The fix is to re-create the inotify watch when the file attributes
change. This is a bit of a performance penalty as most of the time the
attribute changes are simple last modified time/size changes, but since
inotify provides no way to know specifically when the inode has changed,
this is the best we can do.
