### PR TITLE
workaround for _powerline_tmux_setenv() issue with bash-4.2.45

### DIFF
--- a/powerline/bindings/bash/powerline.sh
+++ b/powerline/bindings/bash/powerline.sh
@@ -8,7 +8,7 @@ fi
 
 _powerline_tmux_setenv() {
 	if [[ -n "$TMUX" ]]; then
-		tmux setenv -g TMUX_"$1"_$(tmux display -p "#D" | tr -d %) "$2"
+		tmux setenv -g TMUX_"$1"_`tmux display -p "#D" | tr -d %` "$2"
 		tmux refresh -S
 	fi
 }


### PR DESCRIPTION
fixes Issue #372
