### PR TITLE
A better battery segment

### DIFF
--- a/powerline/config_files/colorschemes/wm/default.json
+++ b/powerline/config_files/colorschemes/wm/default.json
@@ -21,6 +21,8 @@
 		"system_load_good": { "fg": "lightyellowgreen", "bg": "gray0" },
 		"system_load_bad": { "fg": "gold3", "bg": "gray0" },
 		"system_load_ugly": { "fg": "orangered", "bg": "gray0" },
-		"environment": { "fg": "gray8", "bg": "gray0" }
+		"environment": { "fg": "gray8", "bg": "gray0" },
+		"battery": { "fg": "gray8", "bg": "gray0" },
+		"battery_gradient": { "fg": "white_red", "bg": "gray0" }
 	}
 }


### PR DESCRIPTION
Uses the UPower service on linux to display the actual time remaining
before the battery finishes charging/discharging. Also hides itself
automatically if there is no battery or if the battery is fully charged
and on AC power. I haven't bothered with adding the segment to any
themes, as I have a custom theme setup in any case. If someone merges
it, it should probably be put into the tmux and wm themes at least
(replacing the current battery segment).
