### PR TITLE
Vim: add window_title function, used in quickfix theme

### DIFF
--- a/powerline/config_files/colorschemes/vim/default.json
+++ b/powerline/config_files/colorschemes/vim/default.json
@@ -14,6 +14,7 @@
 		"branch:divider":           { "fg": "gray7", "bg": "gray4" },
 		"file_directory":           { "fg": "gray9", "bg": "gray4" },
 		"file_name":                { "fg": "white", "bg": "gray4", "attr": ["bold"] },
+		"window_title":             { "fg": "white", "bg": "gray4" },
 		"file_size":                { "fg": "gray8", "bg": "gray2" },
 		"file_name_no_file":        { "fg": "gray9", "bg": "gray4", "attr": ["bold"] },
 		"file_name_empty":          { "fg": "gray9", "bg": "gray4" },

--- a/powerline/config_files/colorschemes/vim/solarized.json
+++ b/powerline/config_files/colorschemes/vim/solarized.json
@@ -14,6 +14,7 @@
 		"branch:divider":           { "fg": "gray61", "bg": "darkgreencopper" },
 		"file_directory":           { "fg": "lightyellow", "bg": "darkgreencopper" },
 		"file_name":                { "fg": "oldlace", "bg": "darkgreencopper", "attr": ["bold"] },
+		"window_title":             { "fg": "oldlace", "bg": "darkgreencopper" },
 		"file_size":                { "fg": "oldlace", "bg": "darkgreencopper" },
 		"file_name_no_file":        { "fg": "oldlace", "bg": "darkgreencopper", "attr": ["bold"] },
 		"file_name_empty":          { "fg": "oldlace", "bg": "darkgreencopper" },

--- a/powerline/config_files/themes/vim/quickfix.json
+++ b/powerline/config_files/themes/vim/quickfix.json
@@ -9,7 +9,10 @@
 			{
 				"type": "string",
 				"name": "buffer_name",
-				"highlight_group": ["file_name"],
+				"highlight_group": ["file_name"]
+			},
+			{
+				"name": "window_title",
 				"draw_soft_divider": false
 			},
 			{

--- a/powerline/segments/vim.py
+++ b/powerline/segments/vim.py
@@ -245,6 +245,20 @@ def file_type(pl, segment_info):
 
 
 @requires_segment_info
+def window_title(pl, segment_info):
+	'''Return the window title.
+
+	This currently looks at the ``quickfix_title`` window variable,
+	which is used by Syntastic and Vim itself.
+
+	It is used in the quickfix theme.'''
+	try:
+		return segment_info['window'].vars['quickfix_title']
+	except KeyError:
+		return None
+
+
+@requires_segment_info
 def line_percent(pl, segment_info, gradient=False):
 	'''Return the cursor position in the file as a percentage.
 


### PR DESCRIPTION
This is used to display the window title of the quickfix window. Both
Syntastic and Vim use this. See w:quickfix_title.
