### PR TITLE
Add jobnum segment

### DIFF
--- a/powerline/bindings/bash/powerline.sh
+++ b/powerline/bindings/bash/powerline.sh
@@ -30,7 +30,7 @@ _powerline_prompt() {
 	local last_exit_code=$?
 	[[ -z "$POWERLINE_OLD_PROMPT_COMMAND" ]] ||
 		eval $POWERLINE_OLD_PROMPT_COMMAND
-	PS1="$($POWERLINE_COMMAND shell left -r bash_prompt --last_exit_code=$last_exit_code)"
+	PS1="$($POWERLINE_COMMAND shell left -r bash_prompt --last_exit_code=$last_exit_code --jobnum="$(jobs|wc-l)")"
 	_powerline_tmux_set_pwd
 	return $last_exit_code
 }

--- a/powerline/bindings/zsh/powerline.zsh
+++ b/powerline/bindings/zsh/powerline.zsh
@@ -35,8 +35,22 @@ _powerline_install_precmd() {
 		zpython 'powerline_setup()'
 		zpython 'del powerline_setup'
 	else
-		PS1='$($POWERLINE_COMMAND shell left -r zsh_prompt --last_exit_code=$? --last_pipe_status="$pipestatus")'
-		RPS1='$($POWERLINE_COMMAND shell right -r zsh_prompt --last_exit_code=$? --last_pipe_status="$pipestatus")'
+		local add_args='--last_exit_code=$? --last_pipe_status="$pipestatus"'
+		# If you are wondering why I am not using the same code as I use for 
+		# bash ($(jobs|wc -l)): consider the following test:
+		#     echo abc | less
+		#     <C-z>
+		# . This way jobs will print
+		#     [1]  + done       echo abc |
+		#            suspended  less -M
+		# ([ is in first column). You see: any line counting thingie will return 
+		# wrong number of jobs. You need to filter the lines first. Or not use 
+		# jobs built-in at all.
+		#
+		# This and above variants also do not use subshell.
+		add_args+=' --jobnum=${(%):-%j}'
+		PS1='$($POWERLINE_COMMAND shell left -r zsh_prompt '$add_args')'
+		RPS1='$($POWERLINE_COMMAND shell right -r zsh_prompt '$add_args')'
 	fi
 }
 

--- a/powerline/config_files/colorschemes/shell/default.json
+++ b/powerline/config_files/colorschemes/shell/default.json
@@ -1,6 +1,7 @@
 {
 	"name": "Default color scheme for shell prompts",
 	"groups": {
+		"jobnum": { "fg": "brightyellow", "bg": "mediumorange" },
 		"user": { "fg": "white", "bg": "darkblue", "attr": ["bold"] },
 		"superuser": { "fg": "white", "bg": "brightred", "attr": ["bold"] },
 		"virtualenv": { "fg": "white", "bg": "darkcyan" },

--- a/powerline/config_files/colorschemes/shell/solarized.json
+++ b/powerline/config_files/colorschemes/shell/solarized.json
@@ -1,6 +1,7 @@
 {
 	"name": "Solarized Dark",
 	"groups": {
+		"jobnum":             { "fg": "oldlace", "bg": "darkgreencopper" },
 		"user":               { "fg": "oldlace", "bg": "blue", "attr": ["bold"] },
 		"superuser":          { "fg": "oldlace", "bg": "red", "attr": ["bold"] },
 		"virtualenv":         { "fg": "oldlace", "bg": "green" },

--- a/powerline/config_files/themes/shell/default.json
+++ b/powerline/config_files/themes/shell/default.json
@@ -30,6 +30,10 @@
 				"args": {
 					"dir_limit_depth": 3
 				}
+			},
+			{
+				"module": "powerline.segments.shell",
+				"name": "jobnum"
 			}
 		],
 		"right": [

--- a/powerline/segments/shell.py
+++ b/powerline/segments/shell.py
@@ -4,6 +4,21 @@ from powerline.theme import requires_segment_info
 
 
 @requires_segment_info
+def jobnum(pl, segment_info, show_zero=False):
+	'''Return the number of jobs.
+
+	:param bool show_zero:
+		If False (default) shows nothing if there are no jobs. Otherwise shows 
+		zero for no jobs.
+	'''
+	jobnum = segment_info['args'].jobnum
+	if jobnum is None or (not show_zero and jobnum == 0):
+		return None
+	else:
+		return str(jobnum)
+
+
+@requires_segment_info
 def last_status(pl, segment_info):
 	'''Return last exit code.
 

--- a/powerline/shell.py
+++ b/powerline/shell.py
@@ -50,6 +50,7 @@ def get_argparser(parser=None, *args, **kwargs):
 	p.add_argument('-w', '--width', type=int)
 	p.add_argument('--last_exit_code', metavar='INT', type=int)
 	p.add_argument('--last_pipe_status', metavar='LIST', default='', type=lambda s: [int(status) for status in s.split()])
+	p.add_argument('--jobnum', metavar='INT', type=int)
 	p.add_argument('-c', '--config', metavar='KEY.KEY=VALUE', action='append')
 	p.add_argument('-t', '--theme_option', metavar='THEME.KEY.KEY=VALUE', action='append')
 	p.add_argument('-p', '--config_path', metavar='PATH')

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -35,6 +35,17 @@ class TestShell(TestCase):
 			{'contents': '0', 'highlight_group': 'exit_success', 'draw_inner_divider': True}
 		])
 
+	def test_jobnum(self):
+		pl = Pl()
+		segment_info = {'args': Args(jobnum=0)}
+		self.assertEqual(shell.jobnum(pl=pl, segment_info=segment_info), None)
+		self.assertEqual(shell.jobnum(pl=pl, segment_info=segment_info, show_zero=False), None)
+		self.assertEqual(shell.jobnum(pl=pl, segment_info=segment_info, show_zero=True), '0')
+		segment_info = {'args': Args(jobnum=1)}
+		self.assertEqual(shell.jobnum(pl=pl, segment_info=segment_info), '1')
+		self.assertEqual(shell.jobnum(pl=pl, segment_info=segment_info, show_zero=False), '1')
+		self.assertEqual(shell.jobnum(pl=pl, segment_info=segment_info, show_zero=True), '1')
+
 
 class TestCommon(TestCase):
 	def test_hostname(self):


### PR DESCRIPTION
Replaces #596. Differences:
- Tests and metavar.
- Uses “jobnum” name in place of “jobs”.
- Does not use subshell for zsh. Also counts jobs correctly in zsh.
- Adds an option to force showing jobnum segment even if there are no jobs.
