### PR TITLE
add Solarized Light colour theme for Vim

### DIFF
--- a/powerline/config_files/colorschemes/vim/solarizedlight.json
+++ b/powerline/config_files/colorschemes/vim/solarizedlight.json
@@ -1,5 +1,5 @@
 {
-	"name": "Solarized Dark",
+	"name": "Solarized Light",
 	"groups": {
 		"background":               { "fg": "gray13", "bg": "darkgreencopper" },
 		"background:divider":       { "fg": "azure4", "bg": "darkgreencopper" },


### PR DESCRIPTION
Hi, this commit adds the Solarized Light color theme for Vim, adapted from the dark version.
