### PR TITLE
Don't show '//' when using path separator

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -115,7 +115,7 @@ def cwd(pl, segment_info, dir_shorten_len=None, dir_limit_depth=None, use_path_s
 	for part in cwd:
 		if not part:
 			continue
-		if use_path_separator and not part == os.sep:
+		if use_path_separator:
 			part += os.sep
 		ret.append({
 			'contents': part,
@@ -123,8 +123,10 @@ def cwd(pl, segment_info, dir_shorten_len=None, dir_limit_depth=None, use_path_s
 			'draw_inner_divider': draw_inner_divider,
 		})
 	ret[-1]['highlight_group'] = ['cwd:current_folder', 'cwd']
-	if use_path_separator and len(ret) > 1:
+	if use_path_separator:
 		ret[-1]['contents'] = ret[-1]['contents'][:-1]
+		if len(ret) > 1 and ret[0]['contents'][0] == os.sep:
+			ret[0]['contents'] = ret[0]['contents'][1:]
 	return ret
 
 


### PR DESCRIPTION
Currently, the cwd segment is showing //etc when we are in /etc and / when we are in the root file.
This small patch fix this
