### PR TITLE
Add Meslo fonts to the fontconfig file

### DIFF
--- a/font/10-powerline-symbols.conf
+++ b/font/10-powerline-symbols.conf
@@ -70,24 +70,24 @@
 		<family>Meslo LG L</family>
 		<prefer><family>PowerlineSymbols</family></prefer>
 	</alias>
-        <alias>
-                <family>Meslo LG L DZ</family>
+	<alias>
+		<family>Meslo LG L DZ</family>
 		<prefer><family>PowerlineSymbols</family></prefer>
-        </alias>
-        <alias>
-                <family>Meslo LG M</family>
-                <prefer><family>PowerlineSymbols</family></prefer>
-        </alias>
-        <alias>
-                <family>Meslo LG M DZ</family>
-                <prefer><family>PowerlineSymbols</family></prefer>
-        </alias>
-        <alias>
-                <family>Meslo LG S</family>
-                <prefer><family>PowerlineSymbols</family></prefer>
-        </alias>
-        <alias>
-                <family>Meslo LG S DZ</family>
-                <prefer><family>PowerlineSymbols</family></prefer>
-        </alias>
+	</alias>
+	<alias>
+		<family>Meslo LG M</family>
+		<prefer><family>PowerlineSymbols</family></prefer>
+	</alias>
+	<alias>
+		<family>Meslo LG M DZ</family>
+		<prefer><family>PowerlineSymbols</family></prefer>
+	</alias>
+	<alias>
+		<family>Meslo LG S</family>
+		<prefer><family>PowerlineSymbols</family></prefer>
+	</alias>
+	<alias>
+		<family>Meslo LG S DZ</family>
+		<prefer><family>PowerlineSymbols</family></prefer>
+	</alias>
 </fontconfig>


### PR DESCRIPTION
Allow to install powerline-fonts in Meslo via fontconfig.
