### PR TITLE
Added support for git name-rev.

### DIFF
--- a/powerline/lib/vcs/git.py
+++ b/powerline/lib/vcs/git.py
@@ -4,6 +4,7 @@ import os
 import re
 import errno
 
+from subprocess import Popen, PIPE
 from powerline.lib.vcs import get_branch_name as _get_branch_name, get_file_status
 
 _ref_pat = re.compile(br'ref:\s*refs/heads/(.+)')
@@ -17,7 +18,14 @@ def branch_name_from_config_file(directory, config_file):
 	m = _ref_pat.match(raw)
 	if m is not None:
 		return m.group(1).decode('utf-8', 'replace')
-	return raw[:7]
+
+	p = Popen(("git", "name-rev", "--name-only", "--no-undefined", "--always", "HEAD"), stdout=PIPE, stderr=PIPE, cwd=directory)
+	name = p.communicate()[0].strip()
+
+	if(name == raw):
+		return "#" + raw[:7]
+	else:
+		return "#" + name
 
 def git_directory(directory):
 	path = os.path.join(directory, '.git')
@@ -130,8 +138,6 @@ try:
 		def branch(self):
 			return get_branch_name(self.directory)
 except ImportError:
-	from subprocess import Popen, PIPE
-
 	def readlines(cmd, cwd):
 		p = Popen(cmd, shell=False, stdout=PIPE, stderr=PIPE, cwd=cwd)
 		p.stderr.close()


### PR DESCRIPTION
This results in friendlier names when we do not have a branch checked
out. e.g. master~2.
In order to distinguish between checking out a branch and checking out a
commit corresponding to the branch (i.e. a detached head), we prefix
these names with hashes. Commit hashes use the same prefix for
consistency.
