### PR TITLE
Add optional parameter to common.user to hide username if it's an expected value 

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -591,8 +591,11 @@ username = False
 _geteuid = getattr(os, 'geteuid', lambda: 1)
 
 
-def user(pl, segment_info=None):
+def user(pl, segment_info=None, hide_user=None):
 	'''Return the current user.
+
+	:param str hide_user:
+		will suppress display of username if it matches the given string
 
 	Highlights the user with the ``superuser`` if the effective user ID is 0.
 
@@ -603,6 +606,8 @@ def user(pl, segment_info=None):
 		username = _get_user(segment_info)
 	if username is None:
 		pl.warn('Failed to get username')
+		return None
+	if username == hide_user:
 		return None
 	euid = _geteuid()
 	return [{

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -80,6 +80,10 @@ class TestCommon(TestCase):
 						self.assertEqual(common.user(pl=pl, segment_info=segment_info), [
 							{'contents': 'def', 'highlight_group': 'user'}
 						])
+						self.assertEqual(common.user(pl=pl, segment_info=segment_info, hide_user='abc'), [
+							{'contents': 'def', 'highlight_group': 'user'}
+						])
+						self.assertEqual(common.user(pl=pl, segment_info=segment_info, hide_user='def'), None)
 					with replace_attr(common, '_geteuid', lambda: 0):
 						self.assertEqual(common.user(pl=pl, segment_info=segment_info), [
 							{'contents': 'def', 'highlight_group': ['superuser', 'user']}


### PR DESCRIPTION
This mimics some of the functionality @agnoster had in his zsh theme. It allows you to supply a username that you are normally or put that username in an environment variable and hide the common.user segment if it's that value.
