### PR TITLE
A lowercase f for the unit caused the weather segment to silently fail. ...

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -91,7 +91,7 @@ segments that you may want to customize right away:
            "name": "weather",
            "priority": 50,
            "args": {
-               "unit": "f",
+               "unit": "F",
                "location_query": "oslo, norway"
            }
        },


### PR DESCRIPTION
...Putting in a capital F works correctly
