### PR TITLE
Decode always to ensure that the raw value read is unicode

### DIFF
--- a/powerline/lib/path.py
+++ b/powerline/lib/path.py
@@ -1,0 +1,20 @@
+# vim:fileencoding=utf-8:noet
+
+import os
+import sys
+import codecs
+
+filesystem_encoding = sys.getfilesystemencoding()
+if filesystem_encoding is None or codecs.lookup(filesystem_encoding).name == 'ascii':
+	filesystem_encoding = 'utf-8'
+
+def join(prefix, suffix):
+	try:
+		return os.path.join(prefix, suffix)
+	except TypeError:
+		if isinstance(suffix, bytes):
+			suffix = suffix.decode(filesystem_encoding)
+			return os.path.join(prefix, suffix)
+		else:
+			raise
+

--- a/powerline/lib/vcs/git.py
+++ b/powerline/lib/vcs/git.py
@@ -4,6 +4,7 @@ import os
 import re
 import errno
 
+from powerline.lib import path as pathlib
 from powerline.lib.vcs import get_branch_name as _get_branch_name, get_file_status
 
 _ref_pat = re.compile(br'ref:\s*refs/heads/(.+)')
@@ -24,7 +25,7 @@ def git_directory(directory):
 	if os.path.isfile(path):
 		with open(path, 'rb') as f:
 			raw = f.read().partition(b':')[2].strip()
-			return os.path.abspath(os.path.join(directory, raw))
+			return os.path.abspath(pathlib.join(directory, raw))
 	else:
 		return path
 


### PR DESCRIPTION
This was necessary to fix an error when using powerline with Python 3.3.
