### PR TITLE
Fix Syntastic deprecation warning

### DIFF
--- a/powerline/segments/plugin/syntastic.py
+++ b/powerline/segments/plugin/syntastic.py
@@ -22,7 +22,7 @@ def syntastic(pl, err_format='ERR:  {first_line} ({num}) ', warn_format='WARN
 	'''
 	if not int(vim.eval('exists("g:SyntasticLoclist")')):
 		return
-	has_errors = int(vim.eval('g:SyntasticLoclist.current().hasErrorsOrWarningsToDisplay()'))
+	has_errors = not int(vim.eval('g:SyntasticLoclist.current().isEmpty()'))
 	if not has_errors:
 		return
 	errors = vim.eval('g:SyntasticLoclist.current().errors()')


### PR DESCRIPTION
`hasErrorsOrWarningsToDisplay` has been deprecated in Syntastic (https://github.com/scrooloose/syntastic/commit/d629be9)

This fixes the warning that appears when opening a new file:

```
syntastic: warning: function hasErrorsOrWarningsToDisplay() is deprecated, please use !isEmpty() instead
```
