### PR TITLE
Port spotify mac script from tmux-powerline (revised)

### DIFF
--- a/powerline/config_files/colorschemes/tmux/default.json
+++ b/powerline/config_files/colorschemes/tmux/default.json
@@ -22,6 +22,7 @@
 		"system_load_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" },
 		"environment": { "fg": "gray8", "bg": "gray0" },
 		"battery": { "fg": "gray8", "bg": "gray0" },
-		"battery_gradient": { "fg": "white_red", "bg": "gray0" }
+		"battery_gradient": { "fg": "white_red", "bg": "gray0" },
+		"now_playing": { "fg": "gray10", "bg": "black" }
 	}
 }

--- a/powerline/lib/apple_script_runner.py
+++ b/powerline/lib/apple_script_runner.py
@@ -1,0 +1,15 @@
+# vim:fileencoding=utf-8:noet
+
+def asrun(ascript):
+  "Run the given AppleScript and return the standard output and error."
+  from subprocess import Popen, PIPE
+  osa = Popen(['osascript', '-'],
+                         stdin=PIPE,
+                         stdout=PIPE)
+  return osa.communicate(ascript)[0]
+
+def asquote(astr):
+  "Return the AppleScript equivalent of the given string."
+
+  astr = astr.replace('"', '" & quote & "')
+  return '"{}"'.format(astr)

--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -10,6 +10,7 @@ import socket
 from multiprocessing import cpu_count as _cpu_count
 
 from powerline.lib import add_divider_highlight_group
+from powerline.lib.apple_script_runner import asrun, asquote
 from powerline.lib.url import urllib_read, urllib_urlencode
 from powerline.lib.vcs import guess, tree_status
 from powerline.lib.threaded import ThreadedSegment, KwThreadedSegment, with_docstring
@@ -1009,6 +1010,51 @@ class NowPlayingSegment(object):
 			'artist': info.get('xesam:artist')[0],
 			'title': info.get('xesam:title'),
 			'total': self._convert_seconds(info.get('mpris:length') / 1e6),
+		}
+
+	def player_spotify_mac(self, pl):
+		ascript = '''
+		tell application "System Events"
+			set process_list to (name of every process)
+		end tell
+
+		if process_list contains "Spotify" then
+			tell application "Spotify"
+				if player state is playing or player state is paused then
+					set track_name to name of current track
+					set artist_name to artist of current track
+					set album_name to album of current track
+					set track_length to duration of current track
+					set trim_length to 40
+					set now_playing to player state & album_name & artist_name & track_name & track_length
+					if length of now_playing is less than trim_length then
+						set now_playing_trim to now_playing
+					else
+						set now_playing_trim to characters 1 thru trim_length of now_playing as string
+					end if
+				else
+					return player state
+				end if
+
+			end tell
+		else
+			return "stopped"
+		end if
+		'''
+
+		spotify = asrun(ascript)
+
+		spotify_status = spotify.split(", ")
+		state = self._convert_state(spotify_status[0])
+		if state == 'stop':
+			return
+		return {
+			'state': state,
+			'state_symbol': self.STATE_SYMBOLS.get(state),
+			'album': spotify_status[1],
+			'artist': spotify_status[2],
+			'title': spotify_status[3],
+			'total': self._convert_seconds(int(spotify_status[4]))
 		}
 
 	def player_rhythmbox(self, pl):


### PR DESCRIPTION
I've modified @Xlator's PR https://github.com/Lokaltog/powerline/pull/699 with the modifications you recommended (removing color codes, moving the applescript methods out into it's own lib file, removing extra new lines after method).

I also got the segment working out of the box. I was having problems with it displaying (needed the color scheme definition).

Please review my code as I'm not a python developer. I have vim set up to remove trailing spaces and use two space indention. I noticed the contributing guidelines said tabs, so I took that into consideration when editing (double check me though).

I'm not familiar with flake8 or running test suites in python. My code is almost a direct copy of @Xlator's code with some minor changes/deletions so I think it's fine. I'd recommend setting up travis to run your test suite and other contributing tools/checks.

By the way, I tried getting the included spotify segment working but dbus is a pain on OS X. I got dbus, dbus-glib and dbus-python installed so that the script wouldn't complain the lib was missing but for some reason it would error at [`powerline/segements/common.py#L992`](https://github.com/Lokaltog/powerline/blob/a4e8f36f3/powerline/segments/common.py#L992). I didn't debug it any further though.
