### PR TITLE
Add cpu_load_percent colors to tmux

### DIFF
--- a/powerline/config_files/colorschemes/tmux/default.json
+++ b/powerline/config_files/colorschemes/tmux/default.json
@@ -20,6 +20,8 @@
 		"network_load_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" },
 		"system_load": { "fg": "gray8", "bg": "gray0" },
 		"system_load_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" },
+		"cpu_load_percent": { "fg": "gray8", "bg": "gray0" },
+		"cpu_load_percent_gradient": { "fg": "green_yellow_orange_red", "bg": "gray0" },
 		"environment": { "fg": "gray8", "bg": "gray0" },
 		"battery": { "fg": "gray8", "bg": "gray0" },
 		"battery_gradient": { "fg": "white_red", "bg": "gray0" }


### PR DESCRIPTION
Definitions for cpu_load_percent segment colors and gradient where missing
from default tmux color definitions, rendering this segment unusable for tmux
"out-of-the-box".
