### PR TITLE
Fix foggy weather symbol.

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -300,7 +300,7 @@ weather_conditions_icons = {
 	'cloudy':        '☁',
 	'snowy':         '❅',
 	'stormy':        '☈',
-	'foggy':         '〰',
+	'foggy':         '▒',
 	'sunny':         '☼',
 	'night':         '☾',
 	'windy':         '☴',


### PR DESCRIPTION
Use a better available "Medium Shade" unicode symbol instead of
esoteric "Cuneiform Sign Uri3", which is hardly available in many
standard fonts.
