### PR TITLE
Update email imap segment to allow ENV vars usage for credentials

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -807,7 +807,7 @@ class EmailIMAPSegment(KwThreadedSegment):
 	interval = 60
 
 	@staticmethod
-	def key(username, password, server='imap.gmail.com', port=993, folder='INBOX', **kwargs):
+	def key(username=os.getenv('POWERLINE_IMAP_EMAIL'), password=os.getenv('POWERLINE_IMAP_PASSWORD'), server='imap.gmail.com', port=993, folder='INBOX', **kwargs):
 		return _IMAPKey(username, password, server, port, folder)
 
 	def compute_state(self, key):


### PR DESCRIPTION
This pull request fixes the issue #804 

It allows the user to load its credentials from environment variables instead of the json file. Why ? Because I use almost the same dotfiles between my personal and my professional computers. So I had  to duplicate the whole powerline theme just for the email imap segment. 

I think a good alternative could be to load the credentials from the environment, if not defined in the json file. What do you think about that ?
