### PR TITLE
moved _powerline_prompt to front of $PROMPT_COMMAND in bash binding for ...

### DIFF
--- a/powerline/bindings/bash/powerline.sh
+++ b/powerline/bindings/bash/powerline.sh
@@ -48,6 +48,6 @@ _powerline_prompt() {
 }
 
 [[ "$PROMPT_COMMAND" != "${PROMPT_COMMAND/_powerline_prompt/}" ]] ||
-	export PROMPT_COMMAND="${PROMPT_COMMAND}"$'\n'"_powerline_prompt"
+	export PROMPT_COMMAND="_powerline_prompt; ${PROMPT_COMMAND}"
 
 _powerline_init_tmux_support


### PR DESCRIPTION
This change fixes errant behavior of the last_status segment in bash when $PROMPT_COMMAND already exists before the powerline.sh bash binding is sourced. On OS X for instance, $PROMPT_COMMAND is set to `update_terminal_cwd` by default.

Without this, last_status just gets the return code of the previous items in $PROMPT_COMMAND.
