### PR TITLE
Fixed username lookup to be compatible with psutil 2.0

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -513,7 +513,8 @@ try:
 				yield interface, data.bytes_recv, data.bytes_sent
 
 	def _get_user(segment_info):
-		return psutil.Process(os.getpid()).username
+		res = psutil.Process(os.getpid()).username
+		return res if type(res) is str else res()
 
 	class CPULoadPercentSegment(ThreadedSegment):
 		interval = 1


### PR DESCRIPTION
In psutil, all properties of the Process object were turned into methods.
See http://grodola.blogspot.com.au/search/label/psutil for more info.
