### PR TITLE
fix default mode display in zsh bindings

### DIFF
--- a/powerline/bindings/zsh/powerline.zsh
+++ b/powerline/bindings/zsh/powerline.zsh
@@ -75,12 +75,13 @@ _powerline_init_modes_support() {
 		_powerline_set_true_keymap_name "$REPLY"
 	}
 
+	_powerline_add_widget zle-keymap-select _powerline_zle_keymap_select
+	_powerline_set_main_keymap_name
+
 	if [[ "$_POWERLINE_MODE" != vi* ]] ; then
 		export _POWERLINE_DEFAULT_MODE="$_POWERLINE_MODE"
 	fi
 
-	_powerline_add_widget zle-keymap-select _powerline_zle_keymap_select
-	_powerline_set_main_keymap_name
 	precmd_functions+=( _powerline_set_main_keymap_name )
 }
 


### PR DESCRIPTION
_POWERLINE_MODE is empty the first time _powerline_init_modes_support is called. This results in EMACS being displayed at the beginning of my prompt, even though that is my default mode. Since I don't think this is intended, this pull request fixes the ordering to make sure that the default mode has been retrieved.
