### PR TITLE
tmux: Change session block color if prefix pressed

### DIFF
--- a/powerline/bindings/tmux/powerline.conf
+++ b/powerline/bindings/tmux/powerline.conf
@@ -5,7 +5,7 @@ set -g status-interval 2
 set -g status-fg colour231
 set -g status-bg colour234
 set -g status-left-length 20
-set -g status-left '#[fg=colour16,bg=colour254,bold] #S #[fg=colour254,bg=colour234,nobold]#(eval $POWERLINE_COMMAND tmux left)'
+set -g status-left '#{?client_prefix,#[fg=colour254]#[bg=colour31]#[bold],#[fg=colour16]#[bg=colour254]#[bold]} #S #{?client_prefix,#[fg=colour31]#[bg=colour234]#[nobold],#[fg=colour254]#[bg=colour234]#[nobold]}#(eval $POWERLINE_COMMAND tmux left)'
 set -g status-right '#(eval $POWERLINE_COMMAND tmux right -R pane_id=`tmux display -p "#D"`)'
 set -g status-right-length 150
 set -g window-status-format "#[fg=colour244,bg=colour234]#I #[fg=colour240] #[default]#W "


### PR DESCRIPTION
This modification to the tmux powerline binding allows the user to
easily identify when the prefix has been sent. When the prefix has
been sent, the session block changes from white to blue (matching the
color of the active window). This is accomplished using the conditional
functionality of tmux format strings and the 'client_prefix' format
variable. Unfortunately, the tmux parser fails to properly parse out
comma-separated format strings inside a format conditional, so those
have been split out into individual segments as well. Attempting to
re-combine the formats inside the conditionals will break this feature.

Standard session block:
![powerline_std_session_block_tmux](https://cloud.githubusercontent.com/assets/1715252/2849997/47014f68-d0ef-11e3-8a5f-3a19ad913c57.PNG)
Prefix active session block:
![powerline_prefix_active_session_block_tmux](https://cloud.githubusercontent.com/assets/1715252/2850073/0382d196-d0f2-11e3-80f5-3b97f4f37ea1.PNG)
