### PR TITLE
tmux: Colorize the last active window FG

### DIFF
--- a/powerline/bindings/tmux/powerline.conf
+++ b/powerline/bindings/tmux/powerline.conf
@@ -10,6 +10,7 @@ set -g status-right '#(eval $POWERLINE_COMMAND tmux right -R pane_id=`tmux displ
 set -g status-right-length 150
 set -g window-status-format "#[fg=colour244,bg=colour234]#I #[fg=colour240] #[default]#W "
 set -g window-status-current-format "#[fg=colour234,bg=colour31]#[fg=colour117,bg=colour31] #I  #[fg=colour231,bold]#W #[fg=colour31,bg=colour234,nobold]"
+set -g window-status-last-fg colour31
 set-window-option -g window-status-fg colour249
 set-window-option -g window-status-activity-attr none
 set-window-option -g window-status-bell-attr none


### PR DESCRIPTION
Use a feature of tmux v1.8+ to change the FG color of the last active
window to blue. This uses the foo-{attr,bg,fg} format, which is
deprecated (although still available) starting with tmux v1.9 in favor
of the corresponding foo-style variable. However, tmux v1.9 is not yet
ubiquitous enough to move to the foo-style variables. For example, the
latest Ubuntu LTS (14.04) only has tmux v1.8 available in its
repositories, so the foo-{attr,bg,fg} variables prove to be more
'compatible' for now.

For future reference, here is the modification that should be made once
tmux v1.8 is deemed old enough to drop support for (or whenever the
deprecated foo-{attr,bg,fg} variables go away in the latest version of
tmux):

-set -g window-status-last-fg colour31
+set -g window-status-last-style fg=colour31

It might be appropriate to add version checking around some of these
types of options for maximum compatibility, but my initial attempt to
explore version checking in the tmux config file got extremely messy in
a hurry.

Example (window 3 last active):
![powerline_tmux_colorize_last_window](https://cloud.githubusercontent.com/assets/1715252/2858215/1c17052e-d183-11e3-9c47-168ca2d82715.png)
