### PR TITLE
tmux version checking (Issue #869)

### DIFF
--- a/powerline/bindings/tmux/powerline.conf
+++ b/powerline/bindings/tmux/powerline.conf
@@ -15,7 +15,10 @@ set -g status-right '#(eval $POWERLINE_COMMAND tmux right -R pane_id=`tmux displ
 set -g status-right-length 150
 set -g window-status-format "#[fg=colour244,bg=colour234]#I #[fg=colour240] #[default]#W "
 set -g window-status-current-format "#[fg=colour234,bg=colour31]#[fg=colour117,bg=colour31] #I  #[fg=colour231,bold]#W #[fg=colour31,bg=colour234,nobold]"
-set -g window-status-last-fg colour31
+# Version check for window-status-last-style and/or window-status-last-fg functionality
+if-shell '[ $TMUX_VERSION_MAJOR -gt 1 -o \( $TMUX_VERSION_MAJOR -eq 1 -a $TMUX_VERSION_MINOR -ge 9 \) ]' \
+  "set -g window-status-last-style fg=colour31" \
+  'if-shell "[ $TMUX_VERSION_MAJOR -eq 1 -a $TMUX_VERSION_MINOR -ge 8 ]" "set -g window-status-last-fg colour31"'
 set-window-option -g window-status-fg colour249
 set-window-option -g window-status-activity-attr none
 set-window-option -g window-status-bell-attr none


### PR DESCRIPTION
Add version checking functionality for the `tmux` powerline configuration file.

Also, leverage this functionality for two `tmux` features that cause undesired behavior on older `tmux` versions.
