### PR TITLE
Add fish shell's vi-mode support

### DIFF
--- a/powerline/bindings/fish/powerline-setup.fish
+++ b/powerline/bindings/fish/powerline-setup.fish
@@ -11,6 +11,11 @@ function powerline-setup
 		end
 		function --on-variable fish_bind_mode _powerline_bind_mode
 			set -g -x _POWERLINE_MODE $fish_bind_mode
+			if test x$fish_key_bindings != xfish_vi_key_bindings
+				set -g -x _POWERLINE_DEFAULT_MODE default
+			else
+				set -g -e _POWERLINE_DEFAULT_MODE
+			end
 		end
 		function --on-variable POWERLINE_COMMAND _powerline_update
 			set -l addargs "--last_exit_code=\$status --last_pipe_status=\$status --jobnum=(jobs -p | wc -l)"


### PR DESCRIPTION
- Add a _powerline_bind_mode function for fish_bind_mode variable, update _POWERLINE_MODE variable.
- Run _powerline_bind_mode at startup.
