### PR TITLE
[tmux] Make the output string from mpc decode correctly

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -376,7 +376,11 @@ class WeatherSegment(ThreadedSegment):
 			}
 			self.url = 'http://query.yahooapis.com/v1/public/yql?' + urllib_urlencode(query_data)
 
-		raw_response = urllib_read(self.url)
+		try:
+			raw_response = urllib_read(self.url)
+		except Exception:
+			self.error('Failed to connect')
+			return
 		if not raw_response:
 			self.error('Failed to get response')
 			return


### PR DESCRIPTION
When mpd is playing a song with a non-ascii name, `now_playing.split('\n')` will throw the following exception:

```
2014-05-26 08:16:55,651:ERROR:tmux:now_playing:Exception while computing segment: 'ascii' codec can't decode byte 0xc3 in position 57: ordinal not in range(128)
Traceback (most recent call last):
File "/home/ymf/.local/lib64/python2.7/site-packages/powerline/theme.py", line 75, in get_segments
 contents = segment['contents_func'](self.pl, segment_info)
    File "/home/ymf/.local/lib64/python2.7/site-packages/powerline/segment.py", line 96, in <lambda>
 contents_func = lambda pl, segment_info: _contents_func(pl=pl, **args)
    File "/home/ymf/.local/lib64/python2.7/site-packages/powerline/segments/common.py", line 917, in __call__
 func_stats = player_func(**kwargs)
 File "/home/ymf/.local/lib64/python2.7/site-packages/powerline/segments/common.py", line 982, in player_mpd
 now_playing = now_playing.split('\n')
 UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 57: ordinal not in range(128)
```

I guess this is related to locale settings, however, when I copy out the problematic code segment and test it separately in another python file, the error won't come up. Nevertheless, according to http://stackoverflow.com/questions/22267629/unicodedecodeerror-ascii-codec-cant-decode-byte-0xea-in-position-8-ordinal, here is a quick fix.
