### PR TITLE
Handle the connection failure exception in weather segment to avoid glitching

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -376,7 +376,11 @@ class WeatherSegment(ThreadedSegment):
 			}
 			self.url = 'http://query.yahooapis.com/v1/public/yql?' + urllib_urlencode(query_data)
 
-		raw_response = urllib_read(self.url)
+		try:
+			raw_response = urllib_read(self.url)
+		except Exception:
+			self.error('Failed to connect')
+			return
 		if not raw_response:
 			self.error('Failed to get response')
 			return


### PR DESCRIPTION
When the network goes down, weather update will fail to resolve the host and thus `urllib2` will throw an `URLError` exception:

```
2014-05-30 04:40:56,619:ERROR:tmux:WeatherSegment:Exception while updating: <urlopen error [Errno 111] Connection refused>
Traceback (most recent call last):
  File "/home/ymf/.local/lib64/python2.7/site-packages/powerline/lib/threaded.py", line 68, in set_update_value
    self.update_value = self.update(self.update_value)
  File "/home/ymf/.local/lib64/python2.7/site-packages/powerline/segments/common.py", line 380, in update
    raw_response = urllib_read(self.url)
  File "/home/ymf/.local/lib64/python2.7/site-packages/powerline/lib/url.py", line 14, in urllib_read
    return urlopen(url, timeout=10).read().decode('utf-8')
  File "/usr/lib64/python2.7/urllib2.py", line 127, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 404, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.7/urllib2.py", line 422, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 1214, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib64/python2.7/urllib2.py", line 1184, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 111] Connection refused>
```
