### PR TITLE
Fix zpython bindings

### DIFF
--- a/powerline/bindings/zsh/__init__.py
+++ b/powerline/bindings/zsh/__init__.py
@@ -21,16 +21,9 @@ def get_var_config(var):
 
 
 class Args(object):
+	__slots__ = ('last_pipe_status', 'last_exit_code')
 	ext = ['shell']
 	renderer_module = 'zsh_prompt'
-
-	@property
-	def last_exit_code(self):
-		return zsh.last_exit_code()
-
-	@property
-	def last_pipe_status(self):
-		return zsh.pipestatus()
 
 	@property
 	def config(self):
@@ -92,6 +85,13 @@ class Environment(object):
 environ = Environment()
 
 
+class ZshPowerline(ShellPowerline):
+	def precmd(self):
+		self.args.last_pipe_status = zsh.pipestatus()
+		self.args.last_exit_code = zsh.last_exit_code()
+		zsh.eval('_POWERLINE_PARSER_STATE="${(%):-%_}"')
+
+
 class Prompt(object):
 	__slots__ = ('powerline', 'side', 'savedpsvar', 'savedps', 'args', 'theme')
 
@@ -104,7 +104,6 @@ class Prompt(object):
 		self.theme = theme
 
 	def __str__(self):
-		zsh.eval('_POWERLINE_PARSER_STATE="${(%):-%_}"')
 		segment_info = {
 			'args': self.args,
 			'environ': environ,
@@ -144,7 +143,7 @@ def set_prompt(powerline, psvar, side, theme):
 
 
 def setup():
-	powerline = ShellPowerline(Args())
+	powerline = ZshPowerline(Args())
 	used_powerlines.append(powerline)
 	used_powerlines.append(powerline)
 	set_prompt(powerline, 'PS1', 'left', None)
@@ -153,3 +152,4 @@ def setup():
 	set_prompt(powerline, 'RPS2', 'right', 'continuation')
 	set_prompt(powerline, 'PS3', 'left', 'select')
 	atexit.register(shutdown)
+	return powerline

--- a/powerline/bindings/zsh/powerline.zsh
+++ b/powerline/bindings/zsh/powerline.zsh
@@ -99,6 +99,10 @@ _powerline_set_jobnum() {
 	_POWERLINE_JOBNUM=${(%):-%j}
 }
 
+_powerline_update_counter() {
+	zpython '_powerline.precmd()'
+}
+
 _powerline_setup_prompt() {
 	emulate -L zsh
 	for f in "${precmd_functions[@]}"; do
@@ -108,8 +112,9 @@ _powerline_setup_prompt() {
 	done
 	precmd_functions+=( _powerline_set_jobnum )
 	if zmodload libzpython &>/dev/null || zmodload zsh/zpython &>/dev/null ; then
+		precmd_functions+=( _powerline_update_counter )
 		zpython 'from powerline.bindings.zsh import setup as _powerline_setup'
-		zpython '_powerline_setup()'
+		zpython '_powerline = _powerline_setup()'
 		zpython 'del _powerline_setup'
 	else
 		local add_args='--last_exit_code=$? --last_pipe_status="$pipestatus"'


### PR DESCRIPTION
Zsh+zpython no longer correctly display pipestatus segment due to unknown reasons. This PR fixes this problem.
