### PR TITLE
Fix inotify tree watcher bug

### DIFF
--- a/powerline/lib/tree_watcher.py
+++ b/powerline/lib/tree_watcher.py
@@ -119,7 +119,8 @@ class INotifyTreeWatcher(INotify):
 			return
 		path = self.watched_rmap.get(wd, None)
 		if path is not None:
-			self.modified = not self.ignore_event(path, name)
+			if not self.ignore_event(path, name):
+				self.modified = True
 			if mask & self.CREATE:
 				# A new sub-directory might have been created, monitor it.
 				try:

--- a/powerline/lib/vcs/git.py
+++ b/powerline/lib/vcs/git.py
@@ -56,22 +56,18 @@ def do_status(directory, path, func):
 	return func(directory, path)
 
 
-def ignore_event(path, name):
-	# Ignore changes to the index.lock file, since they happen frequently and
-	# dont indicate an actual change in the working tree status
-	return False
-	return path.endswith('.git') and name == 'index.lock'
-
-
 try:
 	import pygit2 as git
 
 	class Repository(object):
-		__slots__ = ('directory', 'ignore_event')
+		__slots__ = ('directory',)
 
 		def __init__(self, directory):
 			self.directory = os.path.abspath(directory)
-			self.ignore_event = ignore_event
+
+		@staticmethod
+		def ignore_event(path, name):
+			return False
 
 		def do_status(self, directory, path):
 			if path:
@@ -154,11 +150,17 @@ except ImportError:
 				yield line[:-1].decode('utf-8')
 
 	class Repository(object):
-		__slots__ = ('directory', 'ignore_event')
+		__slots__ = ('directory',)
 
 		def __init__(self, directory):
 			self.directory = os.path.abspath(directory)
-			self.ignore_event = ignore_event
+
+		@staticmethod
+		def ignore_event(path, name):
+			# Ignore changes to the index.lock file, since they happen 
+			# frequently and dont indicate an actual change in the working tree 
+			# status
+			return path.endswith('.git') and name == 'index.lock'
 
 		def _gitcmd(self, directory, *args):
 			return readlines(('git',) + args, directory)


### PR DESCRIPTION
Change made by @kovidgoyal. Comment:

Fix a bug in the inotify tree watcher that incorrectly marked a tree as 
unchanged if an ignored event happens after a non-ignored event. This allows an 
optimisation in the git backed to be used (ignoring changes to .git/index.lock).
## 

Not including actual commit as I do not think removing pygit2 backend is a good 
idea. Worse, removing pygit2 backend in the same commit fix is added is 
definitely bad idea.

Ref #874.
