### PR TITLE
Fix buffer to string conversion in powerline-config

### DIFF
--- a/powerline/bindings/config.py
+++ b/powerline/bindings/config.py
@@ -34,7 +34,7 @@ def run_tmux_command(*args):
 
 def get_tmux_output(*args):
 	'''Run tmux command and return its output'''
-	return _run_tmux(subprocess.check_output, args)
+	return _run_tmux(subprocess.check_output, args).decode('utf-8')
 
 
 NON_DIGITS = re.compile('[^0-9]+')


### PR DESCRIPTION
I've just fixed an issue when tmux background was not displayed using user config.

``` shell
aegypius $> powerline-config tmux source                                                                                                                                                                                                   
Traceback (most recent call last):
  File "/home/aegypius/.local/bin/powerline-config", line 33, in <module>
    args.function(args)
  File "/home/aegypius/.local/bin/powerline-config", line 15, in <lambda>
    'source': (lambda args: config.source_tmux_files()),
  File "/home/aegypius/.local/lib64/python3.3/site-packages/powerline/bindings/config.py", line 107, in source_tmux_files
    version = get_tmux_version()
  File "/home/aegypius/.local/lib64/python3.3/site-packages/powerline/bindings/config.py", line 47, in get_tmux_version
    _, version_string = version_string.split(' ')
TypeError: Type str doesn't support the buffer API
```
