### PR TITLE
Do not define POWERLINE_COMMAND when not using prompt

### DIFF
--- a/powerline/bindings/tcsh/powerline.tcsh
+++ b/powerline/bindings/tcsh/powerline.tcsh
@@ -5,27 +5,30 @@
 # Guess this relies on `$_` being set as to last argument to previous command 
 # which must be `.` or `source` in this case
 set POWERLINE_SOURCED=($_)
-if ! $?POWERLINE_COMMAND then
-	if ( { which powerline-client > /dev/null } ) then
-		setenv POWERLINE_COMMAND powerline-client
-	else if ( { which powerline > /dev/null } ) then
-		setenv POWERLINE_COMMAND powerline
-	else
-		setenv POWERLINE_COMMAND $POWERLINE_SOURCED:h:h:h:h:q/scripts/powerline
-	endif
-endif
 if ! ( $?POWERLINE_NO_TCSH_TMUX_SUPPORT || $?POWERLINE_NO_SHELL_TMUX_SUPPORT ) then
 	alias _powerline_tmux_set_pwd 'if ( $?TMUX && { tmux refresh -S >&/dev/null } ) tmux setenv -g TMUX_PWD_`tmux display -p "#D" | tr -d %` $PWD:q ; if ( $?TMUX ) tmux refresh -S >&/dev/null'
 	alias cwdcmd "`alias cwdcmd` ; _powerline_tmux_set_pwd"
 endif
 if ! ( $?POWERLINE_NO_TCSH_PROMPT || $?POWERLINE_NO_SHELL_PROMPT ) then
+	if ! $?POWERLINE_COMMAND then
+		if ( { which powerline-client > /dev/null } ) then
+			setenv POWERLINE_COMMAND powerline-client
+		else if ( { which powerline > /dev/null } ) then
+			setenv POWERLINE_COMMAND powerline
+		else
+			setenv POWERLINE_COMMAND $POWERLINE_SOURCED:h:h:h:h:q/scripts/powerline
+		endif
+	endif
+
 	if ( $?POWERLINE_NO_TCSH_ABOVE || $?POWERLINE_NO_SHELL_ABOVE ) then
 		alias _powerline_above true
 	else
 		alias _powerline_above '$POWERLINE_COMMAND shell above --last_exit_code=$POWERLINE_STATUS --width=$POWERLINE_COLUMNS'
 	endif
+
 	alias _powerline_set_prompt 'set prompt="`$POWERLINE_COMMAND shell left -r tcsh_prompt --last_exit_code=$POWERLINE_STATUS --width=$POWERLINE_COLUMNS`"'
 	alias _powerline_set_rprompt 'set rprompt="`$POWERLINE_COMMAND shell right -r tcsh_prompt --last_exit_code=$POWERLINE_STATUS --width=$POWERLINE_COLUMNS` "'
 	alias _powerline_set_columns 'set POWERLINE_COLUMNS=`stty size|cut -d" " -f2` ; set POWERLINE_COLUMNS=`expr $POWERLINE_COLUMNS - 2`'
+
 	alias precmd 'set POWERLINE_STATUS=$? ; '"`alias precmd`"' ; _powerline_set_columns ; _powerline_above ; _powerline_set_prompt ; _powerline_set_rprompt'
 endif

--- a/powerline/bindings/zsh/powerline.zsh
+++ b/powerline/bindings/zsh/powerline.zsh
@@ -1,13 +1,3 @@
-if test -z "${POWERLINE_COMMAND}" ; then
-	if which powerline-client &>/dev/null ; then
-		export POWERLINE_COMMAND=powerline-client
-	elif which powerline &>/dev/null ; then
-		export POWERLINE_COMMAND=powerline
-	else
-		export POWERLINE_COMMAND="$0:A:h:h:h:h/scripts/powerline"
-	fi
-fi
-
 _powerline_columns_fallback() {
 	if which stty &>/dev/null ; then
 		local cols="$(stty size 2>/dev/null)"
@@ -117,19 +107,32 @@ _powerline_update_counter() {
 
 _powerline_setup_prompt() {
 	emulate -L zsh
+
 	for f in "${precmd_functions[@]}"; do
 		if [[ "$f" = "_powerline_set_jobnum" ]]; then
 			return
 		fi
 	done
 	precmd_functions+=( _powerline_set_jobnum )
+
 	VIRTUAL_ENV_DISABLE_PROMPT=1
+
 	if test -z "${POWERLINE_NO_ZSH_ZPYTHON}" && { zmodload libzpython || zmodload zsh/zpython } &>/dev/null ; then
 		precmd_functions+=( _powerline_update_counter )
 		zpython 'from powerline.bindings.zsh import setup as _powerline_setup'
 		zpython '_powerline = _powerline_setup()'
 		zpython 'del _powerline_setup'
 	else
+		if test -z "${POWERLINE_COMMAND}" ; then
+			if which powerline-client &>/dev/null ; then
+				export POWERLINE_COMMAND=powerline-client
+			elif which powerline &>/dev/null ; then
+				export POWERLINE_COMMAND=powerline
+			else
+				export POWERLINE_COMMAND="$0:A:h:h:h:h/scripts/powerline"
+			fi
+		fi
+
 		local add_args='--last_exit_code=$?'
 		add_args+=' --last_pipe_status="$pipestatus"'
 		add_args+=' --renderer_arg="client_id=$$"'


### PR DESCRIPTION
To be consistent with fish and bash
