### PR TITLE
Do not let powerline trigger loading wrong python

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -127,6 +127,25 @@ hand: ``powerline`` is installed and run just like any other plugin using
 
     call vam#ActivateAddons(['powerline'])
 
+.. note::
+    If you use supplied :file:`powerline.vim` file to load powerline there are 
+    additional configuration variables available: ``g:powerline_pycmd`` and 
+    ``g:powerline_pyeval``. First sets command used to load powerline: expected 
+    values are ``"py"`` and ``"py3"``. Second sets function used in statusline, 
+    expected values are ``"pyeval"`` and ``"py3eval"``.
+
+    If ``g:powerline_pycmd`` is set to the one of the expected values then 
+    ``g:powerline_pyeval`` will be set accordingly. If it is set to some other 
+    value then you must also set ``g:powerline_pyeval``. Powerline will not 
+    check that Vim is compiled with Python support if you set 
+    ``g:powerline_pycmd`` to an unexpected value.
+
+    These values are to be used to specify the only Python that is to be loaded 
+    if you have both versions: Vim may disable loading one python version if 
+    other was already loaded. They should also be used if you have two python 
+    versions able to load simultaneously, but with powerline installed only for 
+    python-3 version.
+
 Shell prompts
 -------------
 

--- a/powerline/vim.py
+++ b/powerline/vim.py
@@ -155,16 +155,17 @@ class VimPowerline(Powerline):
 													__main__.__dict__)))
 
 
-def setup(pyeval=None, pycmd=None):
+def setup(pyeval=None, pycmd=None, can_replace_pyeval=True):
 	import sys
 	import __main__
 	if not pyeval:
 		pyeval = 'pyeval' if sys.version_info < (3,) else 'py3eval'
+		can_replace_pyeval = True
 	if not pycmd:
 		pycmd = 'python' if sys.version_info < (3,) else 'python3'
 
 	# pyeval() and vim.bindeval were both introduced in one patch
-	if not hasattr(vim, 'bindeval'):
+	if not hasattr(vim, 'bindeval') and can_replace_pyeval:
 		vim.command(('''
 				function! PowerlinePyeval(e)
 					{pycmd} powerline.pyeval()


### PR DESCRIPTION
Used python version is controlled by `g:powerline_pycmd`. User configuration now 
has top priority: if `g:powerline_pyeval` is set powerline will not try to use 
`pyeval()` emulation in old Vim versions.

Closes #937 as WONTFIX
