### PR TITLE
Added line_count segment for vim.

### DIFF
--- a/powerline/config_files/colorschemes/vim/__main__.json
+++ b/powerline/config_files/colorschemes/vim/__main__.json
@@ -10,6 +10,7 @@
 		"file_directory":   "information:additional",
 		"file_name_empty":  "file_directory",
 		"line_percent":     "information:additional",
+		"line_count":       "line_current",
 		"position":         "information:additional"
 	}
 }

--- a/powerline/segments/vim.py
+++ b/powerline/segments/vim.py
@@ -335,6 +335,12 @@ def line_current(pl, segment_info):
 
 
 @requires_segment_info
+def line_count(pl, segment_info):
+	'''Return the line count of the current buffer.'''
+	return str(len(segment_info['buffer']))
+
+
+@requires_segment_info
 def col_current(pl, segment_info):
 	'''Return the current cursor column.
 	'''

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -687,6 +687,17 @@ class TestVim(TestCase):
 		finally:
 			vim_module._bw(segment_info['bufnr'])
 
+	def test_line_count(self):
+		pl = Pl()
+		segment_info = vim_module._get_segment_info()
+		segment_info['buffer'][0:-1] = [str(i) for i in range(99)]
+		try:
+			self.assertEqual(vim.line_count(pl=pl, segment_info=segment_info), '100')
+			vim_module._set_cursor(50, 0)
+			self.assertEqual(vim.line_count(pl=pl, segment_info=segment_info), '100')
+		finally:
+			vim_module._bw(segment_info['bufnr'])
+
 	def test_position(self):
 		pl = Pl()
 		segment_info = vim_module._get_segment_info()


### PR DESCRIPTION
Added a line_count segment for vim. This allows showing line position in a current/max format, as opposed to just a percentage:

![line_count](https://cloud.githubusercontent.com/assets/384053/3789741/081c5608-1abe-11e4-975d-4e5460bcd570.png)

Resolves issue #556
