### PR TITLE
Do not use argparge for parsing environment

### DIFF
--- a/client/powerline.py
+++ b/client/powerline.py
@@ -42,7 +42,8 @@ fenc = sys.getfilesystemencoding() or 'utf-8'
 if fenc == 'ascii':
 	fenc = 'utf-8'
 
-args = [x.encode(fenc) if isinstance(x, type('')) else x for x in sys.argv[1:]]
+args = [bytes('%x' % (len(sys.argv) - 1))]
+args.extend((x.encode(fenc) if isinstance(x, type('')) else x for x in sys.argv[1:]))
 
 try:
 	cwd = os.getcwd()
@@ -51,17 +52,17 @@ except EnvironmentError:
 else:
 	if isinstance(cwd, type('')):
 		cwd = cwd.encode(fenc)
-	args.append(b'--cwd=' + cwd)
+	args.append(cwd)
 
 
 env = (k + b'=' + v for k, v in os.environ.items())
 env = (x if isinstance(x, bytes) else x.encode(fenc, 'replace') for x in env)
-args.extend((b'--env=' + x for x in env))
+args.extend(env)
 
 EOF = b'\0\0'
 
 for a in args:
-	eintr_retry_call(sock.sendall, a + EOF[0])
+	eintr_retry_call(sock.sendall, a + b'\0')
 
 eintr_retry_call(sock.sendall, EOF)
 
@@ -74,4 +75,4 @@ while True:
 
 sock.close()
 
-print (b''.join(received))
+sys.stdout.write(b''.join(received))

--- a/client/powerline.sh
+++ b/client/powerline.sh
@@ -5,11 +5,12 @@ ADDRESS="powerline-ipc-${UID:-`id -u`}"
 # Warning: env -0 does not work in busybox. Consider switching to parsing 
 # `set` output in this case
 (
+	printf '%x\0' "$#"
 	for argv in "$@" ; do
 		printf '%s\0' "$argv"
 	done
-	env -0 | sed 's/\(\x00\)\([^\x00]\)\|^/\1--env=\2/g'
-	printf -- '--cwd=%s\0' "$PWD"
+	printf '%s\0' "$PWD"
+	env -0
 ) | socat -lf/dev/null -t 10 - abstract-client:"$ADDRESS"
 
 if test $? -ne 0 ; then

--- a/scripts/powerline-daemon
+++ b/scripts/powerline-daemon
@@ -48,8 +48,6 @@ class NonInteractiveArgParser(ArgumentParser):
 
 
 parser = get_argparser(parser=NonInteractiveArgParser, description='powerline daemon')
-parser.add_argument('--cwd', metavar='PATH')
-parser.add_argument('--env', action='append')
 
 EOF = b'EOF\0\0'
 
@@ -67,11 +65,10 @@ class PowerlineDaemon(ShellPowerline):
 		return super(PowerlineDaemon, self).get_log_handler()
 
 
-def render(args):
+def render(args, environ, cwd):
 	global logger
 	global config_loader
-	environ = dict(((k, v) for k, v in (x.partition('=')[0::2] for x in args.env)))
-	cwd = environ.get('PWD', args.cwd or '/')
+	cwd = cwd or environ.get('PWD', '/')
 	segment_info = {
 		'getcwd': lambda: cwd,
 		'home': environ.get('HOME', home),
@@ -175,11 +172,18 @@ def safe_bytes(o, encoding=encoding):
 		return safe_bytes(str(e), encoding)
 
 
+def parse_args(req):
+	args = [x.decode(encoding) for x in req.split(b'\0') if x]
+	numargs = int(args[0], 16)
+	shell_args = parser.parse_args(args[1:numargs + 1])
+	cwd = args[numargs + 1]
+	environ = dict(((k, v) for k, v in (x.partition('=')[0::2] for x in args[numargs + 2:])))
+	return shell_args, environ, cwd
+
+
 def do_render(req):
 	try:
-		args = [x.decode(encoding) for x in req.split(b'\0') if x]
-		args = parser.parse_args(args)
-		return safe_bytes(render(args))
+		return safe_bytes(render(*parse_args(req)))
 	except Exception as e:
 		return safe_bytes(str(e))
 


### PR DESCRIPTION
This PR changes protocol used to connect between powerline clients and powerline daemon to make powerline daemon work faster. I have only relative numbers from profiler though (2/3 of rendering process wasted for parsing socket input were replaced with 1/6), but this part has to be changed as early as possible because it touches used protocol.

Reason why I was looking at profiling at all: shell integration tests make tmux client they run in blink which should be caused by either constant `refresh -S`, powerline-daemon busy by processing shell tests or both. This change did not fix anything regarding the issue though, but I at least removed the most obvious performance problem (I knew the culprint before running the profiler, yet did not expect it to take 2/3 of time).
