### PR TITLE
Fix weather segment display

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -371,7 +371,7 @@ class WeatherSegment(ThreadedSegment):
 											location_data['country_code']])
 			query_data = {
 				'q':
-				'use "http://github.com/yql/yql-tables/raw/master/weather/weather.bylocation.xml" as we;'
+				'use "https://raw.githubusercontent.com/yql/yql-tables/master/weather/weather.bylocation.xml" as we;'
 				'select * from we where location="{0}" and unit="c"'.format(self.location).encode('utf-8'),
 				'format': 'json',
 			}


### PR DESCRIPTION
Most likely a change on GitHub/Yahoo servers made it crash, when
non-robot ready result page (was redirect there previously?) started to appear inside YQL processor.
Using "raw.githubusercontent.com" URL helps and weather icon is again visible.

Closes: Lokaltog/powerline#949

Signed-off-by: Aleksandrs Ļedovskis aleksandrs@ledovskis.lv
