### PR TITLE
Store write result in dummy variable. (should close #964)

### DIFF
--- a/client/powerline.c
+++ b/client/powerline.c
@@ -120,7 +120,7 @@ int main(int argc, char *argv[]) {
 			close(sd);
 			HANDLE_ERROR("read() failed");
 		} else if (i > 0) {
-			(void) write(STDOUT_FILENO, buf, (size_t) i);
+			int _ignored = write(STDOUT_FILENO, buf, (size_t) i);
 		}
 	}
 


### PR DESCRIPTION
GCC (version 4.8.1, Ubuntu) complains about an unused write()
result, even after a cast to void. There seems to be a long
story behind this (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25509).

As never checking any write() results seems a bit more drastic than
simply making a dummy variable, this commit stores the write()
result in a variable _unusued.
