### PR TITLE
Fix NowPlaying segment when comma in artist or title

### DIFF
--- a/powerline/segments/common.py
+++ b/powerline/segments/common.py
@@ -1035,6 +1035,7 @@ class NowPlayingSegment(Segment):
 		}
 
 	def player_spotify_apple_script(self, pl):
+		status_delimiter = '-~`/='
 		ascript = '''
 		tell application "System Events"
 			set process_list to (name of every process)
@@ -1047,13 +1048,8 @@ class NowPlayingSegment(Segment):
 					set artist_name to artist of current track
 					set album_name to album of current track
 					set track_length to duration of current track
-					set trim_length to 40
-					set now_playing to player state & album_name & artist_name & track_name & track_length
-					if length of now_playing is less than trim_length then
-						set now_playing_trim to now_playing
-					else
-						set now_playing_trim to characters 1 thru trim_length of now_playing as string
-					end if
+					set now_playing to "" & player state & "{0}" & album_name & "{0}" & artist_name & "{0}" & track_name & "{0}" & track_length
+					return now_playing
 				else
 					return player state
 				end if
@@ -1062,13 +1058,13 @@ class NowPlayingSegment(Segment):
 		else
 			return "stopped"
 		end if
-		'''
+		'''.format(status_delimiter)
 
 		spotify = asrun(pl, ascript)
 		if not asrun:
 			return None
 
-		spotify_status = spotify.split(", ")
+		spotify_status = spotify.split(status_delimiter)
 		state = self._convert_state(spotify_status[0])
 		if state == 'stop':
 			return None


### PR DESCRIPTION
With this theme configuration:

``` json
{
    "name": "now_playing",
    "align": "r",
    "args": {
        "player": "spotify_apple_script",
        "format": "{artist} - {title}"
    }
}
```

An error will occur when there are commas in the artist or title (e.g. below for title "Time, Patience, Everything"):

``` sh
2014-08-07 11:55:45,798:ERROR:shell:now_playing:Exception while computing segment: invalid literal for int() with base 10: 'Patience'
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/Powerline-beta-py2.7.egg/powerline/theme.py", line 96, in get_segments
    contents = segment['contents_func'](self.pl, segment_info)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/Powerline-beta-py2.7.egg/powerline/segment.py", line 102, in <lambda>
    contents_func = lambda pl, segment_info: _contents_func(pl=pl, **args)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/Powerline-beta-py2.7.egg/powerline/segments/common.py", line 918, in __call__
    func_stats = player_func(**kwargs)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/Powerline-beta-py2.7.egg/powerline/segments/common.py", line 1081, in player_spotify_apple_script
    'total': self._convert_seconds(int(spotify_status[4]))
ValueError: invalid literal for int() with base 10: 'Patience'
```

This commit fixes the issue by using a (very likely) unique delimiter to separate status fields.

It also moves the status length trimming to an optional call parameter. So to trim the now playing status to 40 characters max you would use the config:

``` json
{
    "name": "now_playing",
    "align": "r",
    "args": {
        "player": "spotify_apple_script",
        "format": "{artist} - {title}",
        "trim": 40
    }
}
```
