### PR TITLE
Don't show buffer if it's not listed

### DIFF
--- a/powerline/config_files/themes/vim/tabline.json
+++ b/powerline/config_files/themes/vim/tabline.json
@@ -25,7 +25,10 @@
 						},
 						"priority": 10
 					}
-				]
+				],
+                "args": {
+                    "list_all_buffers": true
+                }
 			},
 			{
 				"type": "string",

--- a/powerline/segments/vim.py
+++ b/powerline/segments/vim.py
@@ -686,9 +686,17 @@ def buffer_updated_segment_info(segment_info, buffer):
 	)
 	return segment_info
 
+def should_be_listed(segment_info, list_all_buffers):
+	shouldbelisted = (
+		list_all_buffers or
+		vim_getbufoption(segment_info, "buflisted") or
+		segment_info["buffer"] == vim.current.buffer
+		)
+	return shouldbelisted
+
 
 @requires_segment_info
-def bufferlister(pl, segment_info):
+def bufferlister(pl, segment_info, list_all_buffers=False):
 	'''List all buffers in segment_info format
 
 	Specifically generates a list of segment info dictionaries with ``buffer`` 
@@ -707,10 +715,10 @@ def bufferlister(pl, segment_info):
 
 	return [
 		(
-			buffer_updated_segment_info(segment_info, buffer),
-			add_multiplier(buffer, {'mode': ('tab' if buffer == cur_buffer else 'nc')})
+			seg_info,
+			add_multiplier(seg_info["buffer"], {'mode': ('tab' if seg_info["buffer"] == cur_buffer else 'nc')})
 		)
-		for buffer in vim.buffers if buffer.options["buflisted"]
+		for seg_info in [ buffer_updated_segment_info(segment_info, buffer) for buffer in vim.buffers ] if should_be_listed(seg_info, list_all_buffers)
 	]
 
 


### PR DESCRIPTION
This prevents deleted or hidden buffers to show up
in buffers segment for single tab or current tab.

When working with lot of buffers and closing them on regular basis,
or when buffers where created by plugins (NERDTree for example)
I ended up with lots of entries in buffer line, although :buffers command
didn't show them.
