### PR TITLE
docs: Fix building the docs without RTD theme.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ version = 'beta'
 release = 'beta'
 exclude_patterns = ['_build']
 pygments_style = 'sphinx'
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'default'
 html_static_path = ['_static']
 html_show_copyright = False
 


### PR DESCRIPTION
Fix building the docs without RTD theme. Take a look at the file, there is a if clause which sets the theme to rtd if found ...
