### PR TITLE
another workaround for _powerline_tmux_setenv() issue with bash-4.2.45

### DIFF
--- a/powerline/bindings/bash/powerline.sh
+++ b/powerline/bindings/bash/powerline.sh
@@ -23,7 +23,7 @@ _powerline_tmux_set_pwd() {
 }
 
 _powerline_tmux_set_columns() {
-	_powerline_tmux_setenv COLUMNS "${COLUMNS:-$(_powerline_columns_fallback)}"
+	_powerline_tmux_setenv COLUMNS "${COLUMNS:-`_powerline_columns_fallback`}"
 }
 
 _powerline_init_tmux_support() {


### PR DESCRIPTION
issue #372 had resurfaced.
