### PR TITLE
Add tab_modified_indicator to the vim segments

### DIFF
--- a/powerline/config_files/themes/vim/tabline.json
+++ b/powerline/config_files/themes/vim/tabline.json
@@ -31,6 +31,11 @@
 						"priority": 10
 					},
 					{
+						"name": "tab_modified_indicator",
+						"exclude_modes": ["buf", "buf_nc"],
+						"priority": 5
+					},
+					{
 						"name": "modified_indicator",
 						"exclude_modes": ["tab", "tab_nc"],
 						"priority": 5

--- a/powerline/segments/vim/__init__.py
+++ b/powerline/segments/vim/__init__.py
@@ -168,6 +168,25 @@ def modified_indicator(pl, segment_info, text='+'):
 
 
 @requires_segment_info
+def tab_modified_indicator(pl, segment_info, text='+'):
+	'''Return a file modified indicator for tabpages.
+
+	:param string text:
+		text to display if any buffer in the current tab is modified
+	'''
+	if 'tabpage' in segment_info:
+		buffers = [dict(buffer=w.buffer) for w in segment_info['tabpage'].windows]
+		modified = [int(vim_getbufoption(buf, 'modified')) != 0 for buf in buffers]
+		ret = text if reduce(lambda x, y: x or y, modified) else None
+		if ret:
+			return [{
+				'contents': ret,
+				'highlight_group': ['modified_indicator'],
+			}]
+	return None
+
+
+@requires_segment_info
 def paste_indicator(pl, segment_info, text='PASTE'):
 	'''Return a paste mode indicator.
 


### PR DESCRIPTION
This indicates in the tabline that any of the open buffers in a tab
page has unsaved modifications (like the default tabline do).
