### PR TITLE
Handle errors from Renderer._set_highlighting

### DIFF
--- a/powerline/__init__.py
+++ b/powerline/__init__.py
@@ -467,7 +467,7 @@ class Powerline(object):
 
 				self.get_module_attr = gen_module_attr_getter(self.pl, self.import_paths, self.imported_modules)
 
-				self.renderer_options.update(
+				mergedicts(self.renderer_options, dict(
 					pl=self.pl,
 					term_truecolor=self.common_config['term_truecolor'],
 					ambiwidth=self.common_config['ambiwidth'],
@@ -480,7 +480,7 @@ class Powerline(object):
 						'shutdown_event': self.shutdown_event,
 						'get_module_attr': self.get_module_attr,
 					},
-				)
+				))
 
 				if not self.run_once and self.common_config['reload_config']:
 					interval = self.common_config['interval']
@@ -535,7 +535,8 @@ class Powerline(object):
 			self._purge_configs('colorscheme')
 			if load_colorscheme:
 				self.colorscheme_config = self.load_colorscheme_config(self.ext_config['colorscheme'])
-			self.renderer_options['colorscheme'] = Colorscheme(self.colorscheme_config, self.colors_config)
+			self.renderer_options['theme_kwargs']['colorscheme'] = (
+				Colorscheme(self.colorscheme_config, self.colors_config))
 
 		if load_theme:
 			self._purge_configs('theme')

--- a/powerline/renderer.py
+++ b/powerline/renderer.py
@@ -36,8 +36,6 @@ class Renderer(object):
 		base class only records this parameter to a ``.local_themes`` attribute.
 	:param dict theme_kwargs:
 		Keyword arguments for ``Theme`` class constructor.
-	:param Colorscheme colorscheme:
-		Colorscheme object that holds colors configuration.
 	:param PowerlineLogger pl:
 		Object used for logging.
 	:param int ambiwidth:
@@ -93,7 +91,6 @@ class Renderer(object):
 	             theme_config,
 	             local_themes,
 	             theme_kwargs,
-	             colorscheme,
 	             pl,
 	             ambiwidth=1,
 	             **options):
@@ -107,7 +104,6 @@ class Renderer(object):
 		self.theme = Theme(theme_config=theme_config, **theme_kwargs)
 		self.local_themes = local_themes
 		self.theme_kwargs = theme_kwargs
-		self.colorscheme = colorscheme
 		self.width_data = {
 			'N': 1,          # Neutral
 			'Na': 1,         # Narrow
@@ -149,21 +145,6 @@ class Renderer(object):
 		overridden by subclasses in case they support local themes.
 		'''
 		self.theme.shutdown()
-
-	def _set_highlighting(self, segment):
-		segment['highlight'] = self.colorscheme.get_highlighting(
-			segment['highlight_group'],
-			segment['mode'],
-			segment.get('gradient_level')
-		)
-		if segment['divider_highlight_group']:
-			segment['divider_highlight'] = self.colorscheme.get_highlighting(
-				segment['divider_highlight_group'],
-				segment['mode']
-			)
-		else:
-			segment['divider_highlight'] = None
-		return segment
 
 	def get_segment_info(self, segment_info, mode):
 		'''Get segment information.
@@ -264,12 +245,7 @@ class Renderer(object):
 	def do_render(self, mode, width, side, line, output_raw, output_width, segment_info, theme):
 		'''Like Renderer.render(), but accept theme in place of matcher_info
 		'''
-		segments = [
-			self._set_highlighting(segment)
-			for segment in (
-				theme.get_segments(side, line, self.get_segment_info(segment_info, mode), mode)
-			)
-		]
+		segments = list(theme.get_segments(side, line, self.get_segment_info(segment_info, mode), mode))
 
 		current_width = 0
 

--- a/powerline/theme.py
+++ b/powerline/theme.py
@@ -31,9 +31,11 @@ class Theme(object):
 	             pl,
 	             get_module_attr,
 	             top_theme,
+	             colorscheme,
 	             main_theme_config=None,
 	             run_once=False,
 	             shutdown_event=None):
+		self.colorscheme = colorscheme
 		self.dividers = theme_config['dividers']
 		self.dividers = dict((
 			(key, dict((k, u(v))
@@ -116,7 +118,15 @@ class Theme(object):
 				if mode not in segment['exclude_modes'] and (
 					not segment['include_modes'] or mode in segment['include_modes']
 				):
-					process_segment(self.pl, side, segment_info, parsed_segments, segment, mode)
+					process_segment(
+						self.pl,
+						side,
+						segment_info,
+						parsed_segments,
+						segment,
+						mode,
+						self.colorscheme,
+					)
 			for segment in parsed_segments:
 				segment['contents'] = segment['before'] + u(segment['contents'] if segment['contents'] is not None else '') + segment['after']
 				# Align segment contents


### PR DESCRIPTION
It is done by moving appropriate get_highlighting calls into segment.py: here
errors from contents_func are handled as well.

This is a “fix” for #480 that will make such failures cause segment to disappear
with better header which should show segment which caused the error.

Closes #480
