### PR TITLE
Remove filler segment type

### DIFF
--- a/docs/source/configuration/reference.rst
+++ b/docs/source/configuration/reference.rst
@@ -370,8 +370,8 @@ ascii                       Theme without any unicode characters at all
     Each segment dictionary has the following options:
 
     ``type``
-        The segment type. Can be one of ``function`` (default), ``string``, 
-        ``filler`` or ``segments_list``:
+        The segment type. Can be one of ``function`` (default), ``string`` or 
+        ``segments_list``:
 
         ``function``
             The segment contents is the return value of the function defined in 

--- a/powerline/lint/__init__.py
+++ b/powerline/lint/__init__.py
@@ -810,13 +810,11 @@ generic_keys = set((
 type_keys = {
 	'function': set(('function', 'args', 'draw_inner_divider')),
 	'string': set(('contents', 'type', 'highlight_group', 'divider_highlight_group')),
-	'filler': set(('type', 'highlight_group', 'divider_highlight_group')),
 	'segment_list': set(('function', 'segments', 'args', 'type')),
 }
 required_keys = {
 	'function': set(('function',)),
 	'string': set(()),
-	'filler': set(),
 	'segment_list': set(('function', 'segments',)),
 }
 highlight_keys = set(('highlight_group', 'name'))

--- a/powerline/renderer.py
+++ b/powerline/renderer.py
@@ -186,11 +186,11 @@ class Renderer(object):
 	def render(self, mode=None, width=None, side=None, line=0, output_raw=False, output_width=False, segment_info=None, matcher_info=None):
 		'''Render all segments.
 
-		When a width is provided, low-priority segments are dropped one at
-		a time until the line is shorter than the width, or only segments
-		with a negative priority are left. If one or more filler segments are
-		provided they will fill the remaining space until the desired width is
-		reached.
+		When a width is provided, low-priority segments are dropped one at 
+		a time until the line is shorter than the width, or only segments 
+		with a negative priority are left. If one or more segments with 
+		``"width": "auto"`` are provided they will fill the remaining space 
+		until the desired width is reached.
 
 		:param str mode:
 			Mode string. Affects contents (colors and the set of segments) of 

--- a/powerline/segment.py
+++ b/powerline/segment.py
@@ -75,14 +75,9 @@ def get_string(data, segment):
 	return data['get_key'](False, segment, None, None, name, 'contents'), None, None, None, name
 
 
-def get_filler(data, segment):
-	return None, None, None, None, None
-
-
 segment_getters = {
 	'function': get_function,
 	'string': get_string,
-	'filler': get_filler,
 	'segment_list': get_function,
 }
 


### PR DESCRIPTION
It was replaced with `"width": "auto"` and is not used anywhere. I do not even 
know whether it works.
