### PR TITLE
Replace g:powerline_config_path Vim variable with …_paths list

### DIFF
--- a/docs/source/configuration/local.rst
+++ b/docs/source/configuration/local.rst
@@ -22,10 +22,10 @@ Vim configuration can be overridden using the following options:
     redefine some value (e.g. segment) in list, only the whole list itself: only 
     dictionaries are merged recursively.
 
-``g:powerline_config_path``
-    Path (must be expanded, ``~`` shortcut is not supported). Points to the 
-    directory which will be searched for configuration. When this option is 
-    present, none of the other locations are searched.
+``g:powerline_config_paths``
+    Paths list (each path must be expanded, ``~`` shortcut is not supported). 
+    Points to the list of directories which will be searched for configuration. 
+    When this option is present, none of the other locations are searched.
 
 ``g:powerline_no_python_error``
     If this variable is set to a true value it will prevent Powerline from reporting 

--- a/powerline/vim.py
+++ b/powerline/vim.py
@@ -119,7 +119,7 @@ class VimPowerline(Powerline):
 
 	def get_config_paths(self):
 		try:
-			return [vim_getvar('powerline_config_path')]
+			return vim_getvar('powerline_config_paths')
 		except KeyError:
 			return super(VimPowerline, self).get_config_paths()
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -646,7 +646,7 @@ class TestVim(TestCase):
 		from powerline.vim import VimPowerline
 		import powerline as powerline_module
 		import vim
-		vim.vars['powerline_config_path'] = '/'
+		vim.vars['powerline_config_paths'] = ['/']
 		with swap_attributes(config, powerline_module):
 			with vim_module._with('environ', TEST='abc'):
 				with get_powerline_raw(config, VimPowerline) as powerline:

--- a/tests/test_local_overrides.vim
+++ b/tests/test_local_overrides.vim
@@ -1,6 +1,6 @@
 #!/usr/bin/vim -S
 set encoding=utf-8
-let g:powerline_config_path = expand('<sfile>:p:h:h') . '/powerline/config_files'
+let g:powerline_config_paths = [expand('<sfile>:p:h:h') . '/powerline/config_files']
 let g:powerline_config_overrides = {'common': {'default_top_theme': 'ascii'}}
 let g:powerline_theme_overrides__default = {'segment_data': {'line_current_symbol': {'contents': 'LN '}, 'branch': {'before': 'B '}}}
 

--- a/tests/test_plugin_file.vim
+++ b/tests/test_plugin_file.vim
@@ -1,6 +1,6 @@
 #!/usr/bin/vim -S
 set encoding=utf-8
-let g:powerline_config_path = expand('<sfile>:p:h:h') . '/powerline/config_files'
+let g:powerline_config_paths = [expand('<sfile>:p:h:h') . '/powerline/config_files']
 tabedit abc
 tabedit def
 try

--- a/tests/test_provided_config_files.py
+++ b/tests/test_provided_config_files.py
@@ -58,7 +58,7 @@ class TestVimConfig(TestCase):
 				with vim_module._with('bufname', '/tmp/foo.txt'):
 					out = powerline.render(vim_module.current.window, 1, vim_module.current.window.number, is_tabline=True)
 					outputs[out] = (-1, (None, None), 'tab')
-					with vim_module._with('globals', powerline_config_path=cfg_path):
+					with vim_module._with('globals', powerline_config_paths=[cfg_path]):
 						exclude = set(('no', 'v', 'V', VBLOCK, 's', 'S', SBLOCK, 'R', 'Rv', 'c', 'cv', 'ce', 'r', 'rm', 'r?', '!'))
 						try:
 							for mode in ['n', 'nc', 'no', 'v', 'V', VBLOCK, 's', 'S', SBLOCK, 'i', 'R', 'Rv', 'c', 'cv', 'ce', 'r', 'rm', 'r?', '!']:

--- a/tests/test_tabline.vim
+++ b/tests/test_tabline.vim
@@ -1,6 +1,6 @@
 #!/usr/bin/vim -S
 set encoding=utf-8
-let g:powerline_config_path = expand('<sfile>:p:h:h') . '/powerline/config_files'
+let g:powerline_config_paths = [expand('<sfile>:p:h:h') . '/powerline/config_files']
 source powerline/bindings/vim/plugin/powerline.vim
 edit abc
 tabedit def


### PR DESCRIPTION
This is for consistency with other powerline bindings that now all do have a way 
to specify a list of paths.
