### PR TITLE
Include args.config_path in the key

### DIFF
--- a/scripts/powerline-daemon
+++ b/scripts/powerline-daemon
@@ -74,6 +74,7 @@ def render(args, environ, cwd):
 		args.renderer_module,
 		tuple(args.config) if args.config else None,
 		tuple(args.theme_option) if args.theme_option else None,
+		tuple(args.config_path) if args.config_path else None,
 	)
 	finish_args(args)
 	powerline = None

--- a/tests/run_daemon_tests.sh
+++ b/tests/run_daemon_tests.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+FAILED=0
+export ADDRESS="powerline-ipc-test-$$"
+echo "Powerline address: $ADDRESS"
+if $PYTHON scripts/powerline-daemon -s$ADDRESS ; then
+	sleep 1
+	if ! ( \
+		$PYTHON client/powerline.py --socket $ADDRESS -p/dev/null shell left | \
+		grep 'file not found'
+	) ; then
+		echo "-p/dev/null argument ignored or not treated properly"
+		FAILED=1
+	fi
+	if ( \
+		$PYTHON client/powerline.py --socket $ADDRESS \
+			-p$PWD/powerline/config_files shell left | \
+		grep 'file not found'
+	) ; then
+		echo "-p/dev/null argument remembered while it should not"
+		FAILED=1
+	fi
+	if ! ( \
+		cd tests && \
+		$PYTHON ../client/powerline.py --socket $ADDRESS \
+			-p$PWD/../powerline/config_files shell left | \
+		grep 'tests'
+	) ; then
+		echo "Output lacks string “tests”"
+		FAILED=1
+	fi
+else
+	echo "Daemon exited with status $?"
+	FAILED=1
+fi
+if $PYTHON scripts/powerline-daemon -s$ADDRESS -k ; then
+	:
+else
+	echo "powerline-daemon -k failed with exit code $?"
+	FAILED=1
+fi
+exit $FAILED

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -332,12 +332,12 @@ if test -z "${ONLY_SHELL}" || test "x${ONLY_SHELL%sh}" != "x${ONLY_SHELL}" || te
 	done
 fi
 
-if ! $PYTHON scripts/powerline-daemon -s$ADDRESS > tests/shell/daemon_log_2 2>&1 ; then
-	echo "Daemon exited with status $?"
-	FAILED=1
-else
+if $PYTHON scripts/powerline-daemon -s$ADDRESS > tests/shell/daemon_log_2 2>&1 ; then
 	sleep 1
 	$PYTHON scripts/powerline-daemon -s$ADDRESS -k
+else
+	echo "Daemon exited with status $?"
+	FAILED=1
 fi
 
 if ! test -z "$(cat tests/shell/daemon_log_2)" ; then


### PR DESCRIPTION
Consider the following script:

```
% powerline-daemon -s powerline-test
% powerline --socket powerline-test -p/dev/null shell left
Config file not found in search paths (/dev/null): config.json
% powerline --socket powerline-test shell left
Config file not found in search paths (/dev/null): config.json
```

Note the problem: second call to powerline does not use offending path, but it 
still emits the error “Config file not found in search paths”.
