### PR TITLE
Add flags argument to vim/plugin/tagbar

### DIFF
--- a/powerline/segments/vim/plugin/tagbar.py
+++ b/powerline/segments/vim/plugin/tagbar.py
@@ -10,7 +10,21 @@ from powerline.segments.vim import window_cached
 
 
 @window_cached
-def current_tag(pl):
+def current_tag(pl, flags='s'):
+	'''Return tag that is near the cursor.
+
+	:param str flags:
+		Specifies additional properties of the displayed tag.  
+		Supported values:
+
+		* s - display complete signature
+		* f - display the full hierarchy of the tag
+		* p - display the raw prototype
+
+		More info at `official doc
+		<https://github.com/majutsushi/tagbar/blob/master/doc/tagbar.txt>`_
+		(search for 'tagbar#currenttag').
+	'''
 	if not int(vim.eval('exists(":Tagbar")')):
 		return
-	return vim.eval('tagbar#currenttag("%s", "")')
+	return vim.eval('tagbar#currenttag("%s", "", "{0}")'.format(flags))


### PR DESCRIPTION
Tagbar plugin supports 3 different formats for displaying a tag string.
A flags arguments was added to current_tag function to support this
feature.
