### PR TITLE
iTerm2 Nightly supports 24bit color

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -43,7 +43,7 @@ if your terminal emulator supports it.
    Name                  OS      Patched font support  Fontconfig support    24-bit color support 
    ===================== ======= ===================== ===================== =====================
    Gvim                  Linux   |i_yes|               |i_no|                |i_yes|
-   iTerm2                OS X    |i_yes|               |i_no|                |i_no|
+   iTerm2                OS X    |i_yes|               |i_no|                |i_partial| [#]_
    Konsole               Linux   |i_yes|               |i_yes|               |i_yes|
    lxterminal            Linux   |i_yes|               |i_yes|               |i_no|
    MacVim                OS X    |i_yes|               |i_no|                |i_yes|
@@ -58,6 +58,7 @@ if your terminal emulator supports it.
 .. |i_no| image:: _static/img/icons/cross.png
 .. |i_partial| image:: _static/img/icons/error.png
 
+.. [#] iTerm2 Nightly builds now support 24bit color.
 .. [#] Must be compiled with ``--enable-unicode3`` for the patched font to work.
 .. [#] Since version 0.5.
 .. [#] Including XFCE terminal and GNOME terminal.


### PR DESCRIPTION
See: 
- https://code.google.com/p/iterm2/issues/detail?id=218
- https://github.com/gnachman/iTerm2/blob/master/tests/24-bit-color.sh

Let me know if you want me to adjust the way this is designated / worded. I wasn't sure the best way to indicate this in your chart. 
