### PR TITLE
Make “powerline-config” without arguments show proper message (python-3*)

### DIFF
--- a/scripts/powerline-config
+++ b/scripts/powerline-config
@@ -63,4 +63,12 @@ if __name__ == '__main__':
 
 	pl = config.create_powerline_logger(args)
 
-	args.function(pl, args)
+	try:
+		function = args.function
+	except AttributeError:
+		# In Python-3* `powerline-config` (without arguments) raises 
+		# AttributeError. I have not found any standard way to display same 
+		# error message as in Python-2*.
+		parser.error('too few arguments')
+	else:
+		function(pl, args)


### PR DESCRIPTION
In Python-3\* it used to show the following:

```
Traceback (most recent call last):
File "/usr/lib/python-exec/python3.3/powerline-config", line 66, in <module>
    args.function(pl, args)
AttributeError: 'Namespace' object has no attribute 'function'
```

now it shows

```
usage: powerline-config [-h] {tmux,shell} ...
powerline-config: error: too few arguments
```

in both python-2.7 and -3.3.

Fixes #1120.
