### PR TITLE
Set POWERLINE_COMMAND to default value if undefined in tmux binding.

### DIFF
--- a/powerline/bindings/tmux/powerline.conf
+++ b/powerline/bindings/tmux/powerline.conf
@@ -1,3 +1,4 @@
+if-shell 'test -z "$POWERLINE_COMMAND"' 'set-environment -g POWERLINE_COMMAND powerline'
 if-shell 'test -z "$POWERLINE_CONFIG_COMMAND"' 'set-environment -g POWERLINE_CONFIG_COMMAND powerline-config'
 
 # Don’t version-check for this core functionality -- anything too old to


### PR DESCRIPTION
Fixes invisible right segment in tmux, as reported in [Debian bug #766637](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766637).
