### PR TITLE
Use different fallback for old Vims

### DIFF
--- a/powerline/bindings/vim/__init__.py
+++ b/powerline/bindings/vim/__init__.py
@@ -135,7 +135,7 @@ if hasattr(vim, 'Function'):
 else:
 	def vim_func_exists(f):
 		try:
-			return bool(int(vim.eval('type(function("{0}")) == 2'.format(f))))
+			return bool(int(vim.eval('exists("*{0}")'.format(f))))
 		except vim.error:
 			return False
 


### PR DESCRIPTION
Reasoning: currently used fallback works well only if relatively recent patches 
are there: specifically the one that transforms Vim errors to Python exceptions.

This variant should work in any case, but it has a downside: it does not test 
whether function exists, it tests whether argument given to vim_func_exists 
denote some callable object (which may as well be global variable with the same 
name). When it comes to CapsLockStatusline I do not care much as I am using 
`vim.eval` to call it and not saving reference to this function somewhere.

Fixes #1146
