### PR TITLE
Replace usage of chr with unichr

### DIFF
--- a/powerline/lint/markedjson/scanner.py
+++ b/powerline/lint/markedjson/scanner.py
@@ -3,7 +3,7 @@ from __future__ import (unicode_literals, division, absolute_import, print_funct
 
 from powerline.lint.markedjson.error import MarkedError
 from powerline.lint.markedjson import tokens
-from powerline.lib.unicode import unicode
+from powerline.lib.unicode import unicode, unichr
 
 
 # Scanner produces tokens of the following types:
@@ -423,7 +423,7 @@ class Scanner:
 								self.get_mark()
 							)
 					code = int(self.prefix(length), 16)
-					chunks.append(chr(code))
+					chunks.append(unichr(code))
 					self.forward(length)
 				else:
 					raise ScannerError(


### PR DESCRIPTION
`powerline-lint` was crashing for me under Python 2 on this line. I traced the issue back to the fact that I used Unicode escapes in my configuration files. `unichr` is used elsewhere, and so it looks like that is what was intended here. This fixes the issue.
