### PR TITLE
Honor CFLAGS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import os
 import sys
 import subprocess
 import logging
+import shlex
 
 from setuptools import setup, find_packages
 
@@ -27,7 +28,10 @@ def compile_client():
 	else:
 		from distutils.ccompiler import new_compiler
 		compiler = new_compiler().compiler
-		subprocess.check_call(compiler + ['-O3', 'client/powerline.c', '-o', 'scripts/powerline'])
+		cflags = os.environ.get('CFLAGS', '-O3')
+		# A normal split would do a split on each space which might be incorrect. The
+		# shlex will not split if a space occurs in an arguments value.
+		subprocess.check_call(compiler + shlex.split(cflags) + ['client/powerline.c', '-o', 'scripts/powerline'])
 
 try:
 	compile_client()


### PR DESCRIPTION
Hi,

distributions normally pass CFLAGS to the compiler. This should be supported in powerline too so e.g. debuginfo packages can be generated.
