### PR TITLE
Some Vims that have vim.vvars do not accept unicode indexes

### DIFF
--- a/powerline/bindings/vim/__init__.py
+++ b/powerline/bindings/vim/__init__.py
@@ -158,7 +158,7 @@ _vim_exists = vim_get_func('exists', rettype='int')
 
 # It may crash on some old vim versions and I do not remember in which patch 
 # I fixed this crash.
-if hasattr(vim, 'vvars') and vim.vvars['version'] > 703:
+if hasattr(vim, 'vvars') and vim.vvars[str('version')] > 703:
 	_vim_to_python_types = {
 		getattr(vim, 'Dictionary', None) or type(vim.bindeval('{}')):
 			lambda value: dict((


### PR DESCRIPTION
Ref #1225
