### PR TITLE
Use status_delimiter as split character

### DIFF
--- a/powerline/segments/common/players.py
+++ b/powerline/segments/common/players.py
@@ -437,7 +437,7 @@ class RDIOPlayerSegment(PlayerSegment):
 		now_playing = asrun(pl, ascript)
 		if not now_playing:
 			return
-		now_playing = now_playing.split('\n')
+		now_playing = now_playing.split(status_delimiter)
 		if len(now_playing) != 6:
 			return
 		state = _convert_state(now_playing[5])


### PR DESCRIPTION
Newlines are not being used as a status delimiter in the applescript for the rdio player above, so don't use them.
