### PR TITLE
Remove all exports from shell bindings

### DIFF
--- a/powerline/bindings/fish/powerline-setup.fish
+++ b/powerline/bindings/fish/powerline-setup.fish
@@ -33,12 +33,9 @@ function powerline-setup
 		if test -z "$POWERLINE_COMMAND"
 			set -g POWERLINE_COMMAND (env $POWERLINE_CONFIG_COMMAND shell command)
 		end
-		function --on-variable fish_bind_mode _powerline_bind_mode
-			set -g -x _POWERLINE_MODE $fish_bind_mode
-		end
 		function --on-variable fish_key_bindings _powerline_set_default_mode
 			if test x$fish_key_bindings != xfish_vi_key_bindings
-				set -g -x _POWERLINE_DEFAULT_MODE default
+				set -g _POWERLINE_DEFAULT_MODE default
 			else
 				set -g -e _POWERLINE_DEFAULT_MODE
 			end
@@ -51,6 +48,8 @@ function powerline-setup
 			# the same value in two shells
 			set -l addargs "$addargs --renderer-arg=client_id="(random)
 			set -l addargs "$addargs --width=\$_POWERLINE_COLUMNS"
+			set -l addargs "$addargs --renderer-arg=mode=\$fish_bind_mode"
+			set -l addargs "$addargs --renderer-arg=default_mode=\$_POWERLINE_DEFAULT_MODE"
 			set -l promptside
 			set -l rpromptpast
 			set -l columnsexpr

--- a/powerline/bindings/zsh/powerline.zsh
+++ b/powerline/bindings/zsh/powerline.zsh
@@ -60,7 +60,7 @@ _powerline_init_modes_support() {
 	}
 
 	function -g _powerline_set_true_keymap_name() {
-		export _POWERLINE_MODE="${1}"
+		_POWERLINE_MODE="${1}"
 		local plm_bk="$(bindkey -lL ${_POWERLINE_MODE})"
 		if [[ $plm_bk = 'bindkey -A'* ]] ; then
 			_powerline_set_true_keymap_name ${(Q)${${(z)plm_bk}[3]}}
@@ -83,7 +83,7 @@ _powerline_init_modes_support() {
 	_powerline_set_main_keymap_name
 
 	if [[ "$_POWERLINE_MODE" != vi* ]] ; then
-		export _POWERLINE_DEFAULT_MODE="$_POWERLINE_MODE"
+		_POWERLINE_DEFAULT_MODE="$_POWERLINE_MODE"
 	fi
 
 	precmd_functions+=( _powerline_set_main_keymap_name )
@@ -145,6 +145,8 @@ _powerline_setup_prompt() {
 		add_args+=' --renderer-arg="client_id=$$"'
 		add_args+=' --renderer-arg="shortened_path=${(%):-%~}"'
 		add_args+=' --jobnum=$_POWERLINE_JOBNUM'
+		add_args+=' --renderer-arg="mode=$_POWERLINE_MODE"'
+		add_args+=' --renderer-arg="default_mode=$_POWERLINE_DEFAULT_MODE"'
 		local new_args_2=' --renderer-arg="parser_state=${(%%):-%_}"'
 		new_args_2+=' --renderer-arg="local_theme=continuation"'
 		local add_args_3=$add_args' --renderer-arg="local_theme=select"'
@@ -179,15 +181,15 @@ _powerline_add_widget() {
 		eval "function $save_widget() { emulate -L zsh; $widget \$@ }"
 		eval "${old_widget_command/$widget/$save_widget}"
 		zle -N $widget $function
-		export _POWERLINE_SAVE_WIDGET="$save_widget"
+		_POWERLINE_SAVE_WIDGET="$save_widget"
 	fi
 }
 
 if test -z "${POWERLINE_CONFIG_COMMAND}" ; then
 	if which powerline-config >/dev/null ; then
-		export POWERLINE_CONFIG_COMMAND=powerline-config
+		POWERLINE_CONFIG_COMMAND=powerline-config
 	else
-		export POWERLINE_CONFIG_COMMAND="$_POWERLINE_SOURCED:h:h:h:h/scripts/powerline-config"
+		POWERLINE_CONFIG_COMMAND="$_POWERLINE_SOURCED:h:h:h:h/scripts/powerline-config"
 	fi
 fi
 

--- a/powerline/commands/main.py
+++ b/powerline/commands/main.py
@@ -82,7 +82,7 @@ def write_output(args, powerline, segment_info, write, encoding):
 		for line in powerline.render_above_lines(
 			width=args.width,
 			segment_info=segment_info,
-			mode=segment_info['environ'].get('_POWERLINE_MODE'),
+			mode=segment_info.get('mode', None),
 		):
 			write(line.encode(encoding, 'replace'))
 			write(b'\n')
@@ -93,6 +93,6 @@ def write_output(args, powerline, segment_info, write, encoding):
 			width=args.width,
 			side=args.side,
 			segment_info=segment_info,
-			mode=segment_info['environ'].get('_POWERLINE_MODE'),
+			mode=segment_info.get('mode', None),
 		)
 		write(rendered.encode(encoding, 'replace'))

--- a/powerline/segments/shell.py
+++ b/powerline/segments/shell.py
@@ -65,11 +65,11 @@ def mode(pl, segment_info, override={'vicmd': 'COMMND', 'viins': 'INSERT'}, defa
 		``$POWERLINE_DEFAULT_MODE`` variable. This variable is set by zsh 
 		bindings for any mode that does not start from ``vi``.
 	'''
-	mode = segment_info['mode']
+	mode = segment_info.get('mode', None)
 	if not mode:
-		pl.debug('No or empty _POWERLINE_MODE variable')
+		pl.debug('No mode specified')
 		return None
-	default = default or segment_info['environ'].get('_POWERLINE_DEFAULT_MODE')
+	default = default or segment_info.get('default_mode', None)
 	if mode == default:
 		return None
 	try:
@@ -78,9 +78,9 @@ def mode(pl, segment_info, override={'vicmd': 'COMMND', 'viins': 'INSERT'}, defa
 		# Note: with zsh line editor you can emulate as much modes as you wish. 
 		# Thus having unknown mode is not an error: maybe just some developer 
 		# added support for his own zle widgets. As there is no built-in mode() 
-		# function like in VimL and _POWERLINE_MODE is likely be defined by our 
-		# code or by somebody knowing what he is doing there is absolutely no 
-		# need in keeping translations dictionary.
+		# function like in VimL and mode is likely be defined by our code or by 
+		# somebody knowing what he is doing there is absolutely no need in 
+		# keeping translations dictionary.
 		return mode.upper()
 
 

--- a/tests/lib/fsconfig.py
+++ b/tests/lib/fsconfig.py
@@ -5,8 +5,8 @@ import os
 import json
 
 from subprocess import check_call
-from operator import add
 from shutil import rmtree
+from itertools import chain
 
 from powerline import Powerline
 
@@ -64,9 +64,12 @@ class FSTree(object):
 			)
 		if os.environ.get('POWERLINE_RUN_LINT_DURING_TESTS'):
 			try:
-				check_call(['scripts/powerline-lint'] + reduce(add, (
-					['-p', d] for d in self.p.get_config_paths()
-				)))
+				check_call(chain(['scripts/powerline-lint'], *[
+					('-p', d) for d in (
+						self.p.get_config_paths() if self.p
+						else self.get_config_paths(self.root)
+					)
+				]))
 			except:
 				self.__exit__()
 				raise


### PR DESCRIPTION
Bindings still use various variables, but they are no longer exported.

Ref #1239.