### PR TITLE
When using `rc` remove “read() failed” messages

### DIFF
--- a/tests/test_shells/postproc.py
+++ b/tests/test_shells/postproc.py
@@ -98,4 +98,7 @@ with codecs.open(fname, 'r', encoding='utf-8') as R:
 				line = IPYPY_DEANSI_RE.subn('', line)[0]
 				if line == '\n' and not was_empty:
 					line = ''
+			elif shell == 'rc':
+				if line == 'read() failed: Connection reset by peer\n':
+					line = ''
 			W.write(line)

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -181,8 +181,13 @@ do_run_test() {
 }
 
 run_test() {
+	TEST_TYPE="$1"
+	TEST_CLIENT="$2"
+	SH="$3"
 	local attempts=3
 	while test $attempts -gt 0 ; do
+		rm -f tests/shell/${SH}.${TEST_TYPE}.${TEST_CLIENT}.log
+		rm -f tests/shell/${SH}.${TEST_TYPE}.${TEST_CLIENT}.full.log
 		do_run_test "$@" && return 0
 		attempts=$(( attempts - 1 ))
 	done


### PR DESCRIPTION
They are causing tests to fail, like in [build 1322.7](https://travis-ci.org/powerline/powerline/jobs/46443873).