### PR TITLE
Add some fixes for testing from ebuild

### DIFF
--- a/client/powerline.sh
+++ b/client/powerline.sh
@@ -46,7 +46,7 @@ fi
 	done
 	printf '%s\0' "$PWD"
 	$ENV -0
-) | socat -lf/dev/null -t 10 - "$ADDRESS"
+) 2>/dev/null | socat -lf/dev/null -t 10 - "$ADDRESS"
 
 if test $? -ne 0 ; then
 	powerline-render "$@"

--- a/powerline/bindings/shell/powerline.sh
+++ b/powerline/bindings/shell/powerline.sh
@@ -224,8 +224,7 @@ fi
 
 # Strips the leading `-`: it may be present when shell is a login shell
 _POWERLINE_USED_SHELL=${0#-}
-_POWERLINE_USED_SHELL=${_POWERLINE_USED_SHELL#/usr}
-_POWERLINE_USED_SHELL=${_POWERLINE_USED_SHELL#/bin/}
+_POWERLINE_USED_SHELL=${_POWERLINE_USED_SHELL##*/}
 
 if "${POWERLINE_CONFIG_COMMAND}" shell uses tmux ; then
 	_powerline_init_tmux_support $_POWERLINE_USED_SHELL

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -5,7 +5,7 @@ git clone --depth=1 git://github.com/powerline/deps tests/bot-ci/deps
 . tests/bot-ci/scripts/common/main.sh
 
 sudo apt-get install -qq libssl1.0.0
-sudo apt-get install -qq screen zsh tcsh mksh busybox socat realpath bc rc tmux
+sudo apt-get install -qq zsh tcsh mksh busybox socat realpath bc rc tmux
 
 if test -n "$USE_UCS2_PYTHON" ; then
 	pip install virtualenvwrapper

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 . tests/bot-ci/scripts/common/main.sh
 
+: ${USER:=`id -un`}
+: ${HOME:=`getent passwd $USER | cut -d: -f6`}
+
+export USER HOME
+
 FAILED=0
 
 export PATH="/opt/fish/bin:${PATH}"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -8,18 +8,20 @@ export USER HOME
 
 FAILED=0
 
-export PATH="/opt/fish/bin:${PATH}"
+if test "$TRAVIS" = true ; then
+	export PATH="/opt/fish/bin:${PATH}"
 
-if test "$PYTHON_IMPLEMENTATION" = "CPython" ; then
-	export PATH="/opt/zsh-${PYTHON_MM}${USE_UCS2_PYTHON:+-ucs2}/bin:${PATH}"
-fi
+	if test "$PYTHON_IMPLEMENTATION" = "CPython" ; then
+		export PATH="/opt/zsh-${PYTHON_MM}${USE_UCS2_PYTHON:+-ucs2}/bin:${PATH}"
+	fi
 
-if test -n "$USE_UCS2_PYTHON" ; then
-	export LD_LIBRARY_PATH="/opt/cpython-ucs2-$UCS2_PYTHON_VARIANT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-	set +e
-	. virtualenvwrapper.sh
-	workon cpython-ucs2-$UCS2_PYTHON_VARIANT
-	set -e
+	if test -n "$USE_UCS2_PYTHON" ; then
+		export LD_LIBRARY_PATH="/opt/cpython-ucs2-$UCS2_PYTHON_VARIANT/lib${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+		set +e
+		. virtualenvwrapper.sh
+		workon cpython-ucs2-$UCS2_PYTHON_VARIANT
+		set -e
+	fi
 fi
 
 export PYTHON="${PYTHON:=python}"

--- a/tests/test_in_vterm/test.sh
+++ b/tests/test_in_vterm/test.sh
@@ -19,8 +19,9 @@ cp -r tests/terminfo tests/vterm
 FAIL_SUMMARY=""
 
 test_tmux() {
-	if test "$PYTHON_IMPLEMENTATION" = PyPy && test "$PYTHON_VERSION_MAJOR" -eq 3 ; then
-		# FIXME PyPy3 segfaults for some reason
+	if test "$PYTHON_IMPLEMENTATION" = PyPy; then
+		# FIXME PyPy3 segfaults for some reason, PyPy does it as well, but 
+		# occasionally.
 		return 0
 	fi
 	if ! which "${POWERLINE_TMUX_EXE}" ; then

--- a/tests/test_in_vterm/test_tmux.py
+++ b/tests/test_in_vterm/test_tmux.py
@@ -223,7 +223,8 @@ def main(attempts=3):
 			expected_result = expected_result_new
 		if not test_expected_result(p, expected_result, cols, rows, not attempts):
 			if attempts:
-				return main(attempts=(attempts - 1))
+				pass
+				# Will rerun main later.
 			else:
 				return False
 		else:
@@ -233,6 +234,7 @@ def main(attempts=3):
 			'PATH': vterm_path,
 			'LD_LIBRARY_PATH': os.environ.get('LD_LIBRARY_PATH', ''),
 		})
+	return main(attempts=(attempts - 1))
 
 
 if __name__ == '__main__':

--- a/tests/test_in_vterm/test_tmux.py
+++ b/tests/test_in_vterm/test_tmux.py
@@ -97,7 +97,7 @@ def test_expected_result(p, expected_result, cols, rows, print_logs):
 
 def main(attempts=3):
 	vterm_path = os.path.join(VTERM_TEST_DIR, 'path')
-	socket_path = os.path.join(VTERM_TEST_DIR, 'tmux-socket')
+	socket_path = 'tmux-socket'
 	rows = 50
 	cols = 200
 
@@ -233,7 +233,7 @@ def main(attempts=3):
 		check_call([tmux_exe, '-S', socket_path, 'kill-server'], env={
 			'PATH': vterm_path,
 			'LD_LIBRARY_PATH': os.environ.get('LD_LIBRARY_PATH', ''),
-		})
+		}, cwd=VTERM_TEST_DIR)
 	return main(attempts=(attempts - 1))
 
 

--- a/tests/test_in_vterm/test_tmux.py
+++ b/tests/test_in_vterm/test_tmux.py
@@ -161,7 +161,7 @@ def main(attempts=3):
 				'TERMINFO': os.path.join(VTERM_TEST_DIR, 'terminfo'),
 				'TERM': 'st-256color',
 				'PATH': vterm_path,
-				'SHELL': os.path.join(''),
+				'SHELL': os.path.join(VTERM_TEST_DIR, 'path', 'bash'),
 				'POWERLINE_CONFIG_PATHS': os.path.abspath('powerline/config_files'),
 				'POWERLINE_COMMAND': 'powerline-render',
 				'POWERLINE_THEME_OVERRIDES': (

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -39,9 +39,9 @@ else:
 	use_mercurial = True
 
 
-GIT_REPO = 'git_repo' + os.environ.get('PYTHON', '')
-HG_REPO = 'hg_repo' + os.environ.get('PYTHON', '')
-BZR_REPO = 'bzr_repo' + os.environ.get('PYTHON', '')
+GIT_REPO = 'git_repo'
+HG_REPO = 'hg_repo'
+BZR_REPO = 'bzr_repo'
 
 
 def thread_number():

--- a/tests/test_shells/postproc.py
+++ b/tests/test_shells/postproc.py
@@ -118,4 +118,6 @@ with codecs.open(fname, 'r', encoding='utf-8') as R:
 					line = ''
 				elif line == '-> self.quitting = 1\n':
 					line = '-> self.quitting = True\n'
+				elif line == '\n':
+					line = ''
 			W.write(line)

--- a/tests/test_shells/postproc.py
+++ b/tests/test_shells/postproc.py
@@ -31,6 +31,10 @@ user = os.environ['USER']
 REFS_RE = re.compile(r'^\[\d+ refs\]\n')
 IPYPY_DEANSI_RE = re.compile(r'\033(?:\[(?:\?\d+[lh]|[^a-zA-Z]+[a-ln-zA-Z])|[=>])')
 
+start_str = 'cd tests/shell/3rd'
+if shell == 'pdb':
+	start_str = 'class Foo(object):'
+
 with codecs.open(fname, 'r', encoding='utf-8') as R:
 	with codecs.open(new_fname, 'w', encoding='utf-8') as W:
 		found_cd = False
@@ -38,11 +42,7 @@ with codecs.open(fname, 'r', encoding='utf-8') as R:
 		for line in (R if shell != 'fish' else R.read().split('\n')):
 			i += 1
 			if not found_cd:
-				found_cd = (
-					'class Foo(object):' in line
-					if shell == 'pdb' else
-					'cd tests/shell/3rd' in line
-				)
+				found_cd = (start_str in line)
 				continue
 			if 'true is the last line' in line:
 				break

--- a/tests/test_shells/postproc.py
+++ b/tests/test_shells/postproc.py
@@ -120,4 +120,6 @@ with codecs.open(fname, 'r', encoding='utf-8') as R:
 					line = '-> self.quitting = True\n'
 				elif line == '\n':
 					line = ''
+				if line == '-> self.quitting = True\n':
+					break
 			W.write(line)

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -108,6 +108,8 @@ def main():
 			else:
 				LF.write(s)
 
+	child.close(force=True)
+
 	check_call([
 		os.path.join('tests', 'shell', 'path', 'python'),
 		os.path.join('tests', 'test_shells', 'postproc.py'),

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -82,6 +82,7 @@ def main():
 		args.command[1:],
 		env=environ,
 		logfile=sio,
+		timeout=60 * 3,
 	)
 	child.expect(re.compile(b'.*'))
 	sleep(0.5)

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# vim:fileencoding=utf-8:noet
+from __future__ import (unicode_literals, division, absolute_import, print_function)
+
+import argparse
+import os
+import re
+
+from time import sleep
+from subprocess import check_call
+
+import pexpect
+
+
+def get_argparser(ArgumentParser=argparse.ArgumentParser):
+	parser = ArgumentParser(description='Run powerline shell test using pexpect')
+	parser.add_argument('--wait-for-echo', action='store_true', help='Wait until the input is echoed back.')
+	parser.add_argument('--type', metavar='TYPE', help='Test type (daemon, nodaemon, …).')
+	parser.add_argument('--client', metavar='CLIENT', help='Type of the client used (C, shell, zpython, …).')
+	parser.add_argument('--shell', metavar='SHELL', help='Shell name.')
+	parser.add_argument('command', required=True, nargs=argparse.REMAINDER, metavar='COMMAND',
+	                    help='Command to run and its argument.')
+	return parser
+
+
+def main():
+	parser = get_argparser()
+	args = parser.parse_args()
+
+	shell = args.shell or args.command[0]
+	test_type = args.test_type or shell
+	test_client = args.test_client or test_type
+
+	log_file_base = '{0}.{1}.{2}'.format(shell, test_type, test_client)
+	full_log_file_name = os.path.join('tests', 'shell', '{0}.full.log'.format(log_file_base))
+	# postproc_log_file_name = os.path.join('tests', 'shell', '{0}.log'.format(log_file_base))
+
+	local_paths = [
+		os.path.abspath(os.path.join('tests', 'shell', 'path')),
+		os.path.abspath('scripts'),
+	]
+
+	if test_type == 'fish':
+		local_paths += ['/usr/bin', '/bin']
+
+	python_paths = os.environ.get('PYTHONPATH', '')
+	if python_paths:
+		python_paths = ':' + python_paths
+	python_paths = os.path.abspath('.') + python_paths
+
+	environ = {
+		'LANG': 'en_US.UTF-8',
+		'PATH': os.pathsep.join(local_paths),
+		'TERM': 'screen-256color',
+		'DIR1': os.environ['DIR1'],
+		'DIR2': os.environ['DIR2'],
+		'XDG_CONFIG_HOME': os.path.abspath(os.path.join('tests', 'shell', 'fish_home')),
+		'IPYTHONDIR': os.path.abspath(os.path.join('tests', 'shell', 'ipython_home')),
+		'PYTHONPATH': python_paths,
+		'POWERLINE_CONFIG_OVERRIDES': os.environ.get('POWERLINE_CONFIG_OVERRIDES', ''),
+		'POWERLINE_THEME_OVERRIDES': os.environ.get('POWERLINE_THEME_OVERRIDES', ''),
+		'POWERLINE_CONFIG_PATHS': os.path.abspath(os.path.join('powerline', 'config_files')),
+		'POWERLINE_COMMAND_ARGS': os.environ.get('POWERLINE_COMMAND_ARGS', ''),
+		'POWERLINE_COMMAND': os.environ.get('POWERLINE_COMMAND', ''),
+		'LD_LIBRARY_PATH': os.environ.get('LD_LIBRARY_PATH', ''),
+	}
+
+	if test_type == 'daemon':
+		environ['POWERLINE_SHELL_CONTINUATION'] = '1'
+		environ['POWERLINE_SHELL_SELECT'] = '1'
+
+	child = pexpect.spawn(
+		args.command[0],
+		args.command[1:],
+		logfile=open(full_log_file_name),
+		env=environ,
+	)
+	child.expect(re.compile('.*'))
+	sleep(0.5)
+	child.setwinsize(1, 300)
+
+	with open(os.path.join('tests', 'test_shells', 'input.{0}'.format(shell)), 'rb') as F:
+		if not args.wait_for_echo:
+			child.send(F.read())
+		else:
+			for line in F:
+				child.send(line)
+				sleep(1)
+				# TODO Implement something more smart
+
+	child.wait()
+
+	check_call([
+		os.path.join('tests', 'shell', 'path', 'python'),
+		os.path.join('tests', 'test_shells', 'postproc.py'),
+		test_type, test_client, shell
+	])
+	pidfile = os.path.join('tests', 'shell', '3rd', 'pid')
+	if os.path.exists(pidfile):
+		os.unlink(pidfile)
+
+
+if __name__ == '__main__':
+	main()

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -98,7 +98,15 @@ def main():
 				# TODO Implement something more smart
 
 	with open(full_log_file_name, 'wb') as LF:
-		LF.write(child.read())
+		while True:
+			try:
+				s = child.read_nonblocking(1000)
+			except pexpect.TIMEOUT:
+				break
+			except pexpect.EOF:
+				break
+			else:
+				LF.write(s)
 
 	check_call([
 		os.path.join('tests', 'shell', 'path', 'python'),

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -82,7 +82,7 @@ def main():
 		args.command[1:],
 		env=environ,
 		logfile=sio,
-		timeout=60 * 3,
+		timeout=30,
 	)
 	child.expect(re.compile(b'.*'))
 	sleep(0.5)

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -98,7 +98,7 @@ def main():
 
 	child.wait()
 
-	with open(full_log_file_name, 'w') as LF:
+	with open(full_log_file_name, 'wb') as LF:
 		LF.write(child.read())
 
 	check_call([

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -12,8 +12,6 @@ from io import BytesIO
 
 import pexpect
 
-from powerline.lib.monotonic import monotonic
-
 
 def get_argparser(ArgumentParser=argparse.ArgumentParser):
 	parser = ArgumentParser(description='Run powerline shell test using pexpect')
@@ -97,14 +95,6 @@ def main():
 				child.send(line)
 				sleep(1)
 				# TODO Implement something more smart
-
-	start = monotonic()
-	while child.isalive():
-		sleep(0.1)
-		if monotonic() - start > 60 * 3:
-			# Waiting for three minutes. This is long enough.
-			child.kill()
-			break
 
 	with open(full_log_file_name, 'wb') as LF:
 		LF.write(child.read())

--- a/tests/test_shells/run_script.py
+++ b/tests/test_shells/run_script.py
@@ -12,6 +12,8 @@ from io import BytesIO
 
 import pexpect
 
+from powerline.lib.monotonic import monotonic
+
 
 def get_argparser(ArgumentParser=argparse.ArgumentParser):
 	parser = ArgumentParser(description='Run powerline shell test using pexpect')
@@ -96,7 +98,13 @@ def main():
 				sleep(1)
 				# TODO Implement something more smart
 
-	child.wait()
+	start = monotonic()
+	while child.isalive():
+		sleep(0.1)
+		if monotonic() - start > 60 * 3:
+			# Waiting for three minutes. This is long enough.
+			child.kill()
+			break
 
 	with open(full_log_file_name, 'wb') as LF:
 		LF.write(child.read())

--- a/tests/test_shells/screenrc
+++ b/tests/test_shells/screenrc
@@ -1,7 +1,0 @@
-width  1024
-height    1
-logfile "tests/shell/${SH}.${TEST_TYPE}.${TEST_CLIENT}.full.log"
-# Having utf8 setting on causes screen to recode file passed to readreg. Adding 
-# `-e utf8` just after `readreg` causes screen to fail with `-X: copyreg: 
-# character, ^x, or (octal) \032 expected.` in place of fixing the issue.
-defutf8 off

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -80,10 +80,6 @@ do_run_test() {
 	if ( \
 		test "x${SH}" = "xdash" \
 		|| ( \
-			test "x${SH}" = "xipython" \
-			&& test "$PYTHON_IMPLEMENTATION" = "PyPy" \
-		) \
-		|| ( \
 			test "x${SH}" = "xpdb" \
 			&& ( \
 				( \

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -457,7 +457,7 @@ if test "x${ONLY_SHELL}" = "x" || test "x${ONLY_SHELL}" = "xipython" ; then
 		# Define some overrides which should be ignored by IPython.
 		export POWERLINE_CONFIG_OVERRIDES='common.term_escape_style=fbterm'
 		export POWERLINE_THEME_OVERRIDES='in.segments.left=[]'
-		echo "> $(which ipython)"
+		echo "> ipython"
 		if ! run_test ipython ipython ${IPYTHON_PYTHON} -mIPython ; then
 			FAILED=1
 			FAIL_SUMMARY="${FAIL_SUMMARY}${NL}T ipython"

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -215,6 +215,8 @@ done
 
 ln -s python tests/shell/path/pdb
 PDB_PYTHON=pdb
+ln -s python tests/shell/path/ipython
+IPYTHON_PYTHON=ipython
 
 if test -z "$POWERLINE_RC_EXE" ; then
 	if which rc-status >/dev/null ; then
@@ -230,7 +232,7 @@ if which "$POWERLINE_RC_EXE" >/dev/null ; then
 	ln -s "$(which $POWERLINE_RC_EXE)" tests/shell/path/rc
 fi
 
-for exe in bash zsh busybox fish tcsh mksh dash ipython ; do
+for exe in bash zsh busybox fish tcsh mksh dash ; do
 	if which $exe >/dev/null ; then
 		if test "$exe" = "fish" ; then
 			fish_version="$(fish --version 2>&1)"
@@ -451,12 +453,12 @@ if  test "x${ONLY_SHELL}" = "x" || test "x${ONLY_SHELL}" = "xpdb" ; then
 fi
 
 if test "x${ONLY_SHELL}" = "x" || test "x${ONLY_SHELL}" = "xipython" ; then
-	if which ipython >/dev/null ; then
+	if "${PYTHON}" -c "try: import IPython${NL}except ImportError: raise SystemExit(1)" ; then
 		# Define some overrides which should be ignored by IPython.
 		export POWERLINE_CONFIG_OVERRIDES='common.term_escape_style=fbterm'
 		export POWERLINE_THEME_OVERRIDES='in.segments.left=[]'
 		echo "> $(which ipython)"
-		if ! run_test ipython ipython ipython ; then
+		if ! run_test ipython ipython ${IPYTHON_PYTHON} -mIPython ; then
 			FAILED=1
 			FAIL_SUMMARY="${FAIL_SUMMARY}${NL}T ipython"
 		fi

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -173,7 +173,6 @@ cp -r tests/test_shells/ipython_home tests/shell
 
 mkdir tests/shell/path
 ln -s "$(which "${PYTHON}")" tests/shell/path/python
-ln -s "$(which screen)" tests/shell/path
 ln -s "$(which env)" tests/shell/path
 ln -s "$(which git)" tests/shell/path
 ln -s "$(which sleep)" tests/shell/path
@@ -347,9 +346,8 @@ if test -z "${ONLY_SHELL}" || test "x${ONLY_SHELL%sh}" != "x${ONLY_SHELL}" || te
 			if test "x$ONLY_TEST_CLIENT" != "x" && test "x$TEST_CLIENT" != "x$ONLY_TEST_CLIENT" ; then
 				continue
 			fi
-			POWERLINE_COMMAND_ARGS="--socket $ADDRESS"
-			POWERLINE_COMMAND="$POWERLINE_COMMAND"
-			export POWERLINE_COMMAND
+			export POWERLINE_COMMAND_ARGS="--socket $ADDRESS"
+			export POWERLINE_COMMAND="$POWERLINE_COMMAND"
 			echo ">> powerline command is ${POWERLINE_COMMAND:-empty}"
 			J=-1
 			for TEST_COMMAND in \
@@ -455,8 +453,8 @@ fi
 if test "x${ONLY_SHELL}" = "x" || test "x${ONLY_SHELL}" = "xipython" ; then
 	if which ipython >/dev/null ; then
 		# Define some overrides which should be ignored by IPython.
-		POWERLINE_CONFIG_OVERRIDES='common.term_escape_style=fbterm'
-		POWERLINE_THEME_OVERRIDES='in.segments.left=[]'
+		export POWERLINE_CONFIG_OVERRIDES='common.term_escape_style=fbterm'
+		export POWERLINE_THEME_OVERRIDES='in.segments.left=[]'
 		echo "> $(which ipython)"
 		if ! run_test ipython ipython ipython ; then
 			FAILED=1

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -426,7 +426,7 @@ if ( test "x${ONLY_SHELL}" = "x" || test "x${ONLY_SHELL}" = "xzsh" ) \
 fi
 
 if  test "x${ONLY_SHELL}" = "x" || test "x${ONLY_SHELL}" = "xpdb" ; then
-	if ! ( test "$PYTHON_IMPLEMENTATION" = "PyPy" && test "$PYTHON_VERSION_MAJOR" = 2 ) ; then
+	if test "$PYTHON_IMPLEMENTATION" != "PyPy" ; then
 		if test "x${ONLY_TEST_TYPE}" = "x" || test "x${ONLY_TEST_TYPE}" = "xsubclass" ; then
 			echo "> pdb subclass"
 			if ! run_test subclass python $PDB_PYTHON "$PWD/tests/test_shells/pdb-main.py" ; then

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -352,6 +352,9 @@ for exe in bash zsh busybox fish tcsh mksh dash ipython ; do
 	fi
 done
 
+mkdir tests/shell/home
+export HOME="$PWD/tests/shell/home"
+
 unset ENV
 
 export ADDRESS="powerline-ipc-test-$$"

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -421,7 +421,7 @@ fi
 
 if ( test "x${ONLY_SHELL}" = "x" || test "x${ONLY_SHELL}" = "xzsh" ) \
 	&& ( test "x${ONLY_TEST_TYPE}" = "x" || test "x${ONLY_TEST_TYPE}" = "xzpython" ) \
-	&& zsh -f -c 'zmodload libzpython' 2>/dev/null; then
+	&& zsh tests/test_shells/zsh_test_script.zsh 2>/dev/null; then
 	echo "> zpython"
 	if ! run_test zpython zpython zsh -f -i ; then
 		FAILED=1

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -99,11 +99,13 @@ print_full_output() {
 	echo "Full output:"
 	echo '============================================================'
 	cat tests/shell/${SH}.${TEST_TYPE}.${TEST_CLIENT}.full.log
+	echo
 	echo '____________________________________________________________'
 	if test "x$POWERLINE_TEST_NO_CAT_V" != "x1" ; then
 		echo "Full output (cat -v):"
 		echo '============================================================'
 		cat -v tests/shell/${SH}.${TEST_TYPE}.${TEST_CLIENT}.full.log
+		echo
 		echo '____________________________________________________________'
 	fi
 }

--- a/tests/test_shells/zsh_test_script.zsh
+++ b/tests/test_shells/zsh_test_script.zsh
@@ -1,0 +1,9 @@
+set -e
+. tests/bot-ci/scripts/common/main.sh
+zmodload zpython
+zpython 'import platform'
+zpython 'zsh.setvalue("ZSH_PYTHON_VERSION", platform.python_version())'
+zpython 'zsh.setvalue("ZSH_PYTHON_IMPLEMENTATION", platform.python_implementation())'
+
+[[ $ZSH_PYTHON_IMPLEMENTATION = $PYTHON_IMPLEMENTATION ]]
+[[ $ZSH_PYTHON_VERSION = $PYTHON_VERSION ]]


### PR DESCRIPTION
Dash tests still do not work, but now they do not work completely, not “are not stable” (#931). Alongside with other small fixes this PR switches from screen for shell tests to pexpect.