### PR TITLE
Add warning:regular to default color scheme

### DIFF
--- a/powerline/config_files/colorschemes/default.json
+++ b/powerline/config_files/colorschemes/default.json
@@ -5,6 +5,7 @@
 		"information:regular":       { "fg": "gray10", "bg": "gray4", "attrs": ["bold"] },
 		"information:highlighted":   { "fg": "white", "bg": "gray4", "attrs": [] },
 		"information:priority":      { "fg": "brightyellow", "bg": "mediumorange", "attrs": [] },
+		"warning:regular":           { "fg": "white", "bg": "darkestred", "attrs": [] },
 		"critical:failure":          { "fg": "white", "bg": "darkestred", "attrs": [] },
 		"critical:success":          { "fg": "white", "bg": "darkestgreen", "attrs": [] },
 		"background":                { "fg": "white", "bg": "gray0", "attrs": [] },


### PR DESCRIPTION
Tried setting up the email_imap_alert with the default scheme, but it crashed saying that the highlight color group 'email_alert' couldn't be found. This seems to fix it.