### PR TITLE
Add missing highlight groups

### DIFF
--- a/powerline/config_files/colorschemes/default.json
+++ b/powerline/config_files/colorschemes/default.json
@@ -5,6 +5,7 @@
 		"information:regular":       { "fg": "gray10", "bg": "gray4", "attrs": ["bold"] },
 		"information:highlighted":   { "fg": "white", "bg": "gray4", "attrs": [] },
 		"information:priority":      { "fg": "brightyellow", "bg": "mediumorange", "attrs": [] },
+		"warning:regular":           { "fg": "white", "bg": "brightred", "attrs": ["bold"] },
 		"critical:failure":          { "fg": "white", "bg": "darkestred", "attrs": [] },
 		"critical:success":          { "fg": "white", "bg": "darkestgreen", "attrs": [] },
 		"background":                { "fg": "white", "bg": "gray0", "attrs": [] },

--- a/powerline/config_files/colorschemes/vim/__main__.json
+++ b/powerline/config_files/colorschemes/vim/__main__.json
@@ -23,9 +23,10 @@
 		"csv:column_number": "line_current",
 		"csv:column_name":   "line_current_symbol",
 
-		"tab_nc:file_directory": "information:unimportant",
-		"tab_nc:file_name":      "tab_nc:file_directory",
-		"tab_nc:tabnr":          "tab_nc:file_directory",
+		"tab_nc:modified_indicator": "modified_indicator",
+		"tab_nc:file_directory":     "information:unimportant",
+		"tab_nc:file_name":          "tab_nc:file_directory",
+		"tab_nc:tabnr":              "tab_nc:file_directory",
 
 		"buf_nc:file_directory":     "tab_nc:file_directory",
 		"buf_nc:file_name":          "tab_nc:file_name",

--- a/powerline/lint/checks.py
+++ b/powerline/lint/checks.py
@@ -173,41 +173,47 @@ def check_group(group, data, context, echoerr):
 		return True, False, False
 	colorscheme = data['colorscheme']
 	ext = data['ext']
-	configs = []
+	configs = None
 	if ext:
+		def listed_key(d, k):
+			try:
+				return [d[k]]
+			except KeyError:
+				return []
+
 		if colorscheme == '__main__':
-			configs.append([config for config in data['ext_colorscheme_configs'][ext].items()])
-			configs.append([config for config in data['top_colorscheme_configs'].items()])
+			colorscheme_names = set(data['ext_colorscheme_configs'][ext])
+			colorscheme_names.update(data['top_colorscheme_configs'])
+			colorscheme_names.discard('__main__')
+			configs = [
+				(
+					name,
+					listed_key(data['ext_colorscheme_configs'][ext], name)
+					+ listed_key(data['ext_colorscheme_configs'][ext], '__main__')
+					+ listed_key(data['top_colorscheme_configs'], name)
+				)
+				for name in colorscheme_names
+			]
 		else:
-			try:
-				configs.append([data['ext_colorscheme_configs'][ext][colorscheme]])
-			except KeyError:
-				pass
-			try:
-				configs.append([data['ext_colorscheme_configs'][ext]['__main__']])
-			except KeyError:
-				pass
-			try:
-				configs.append([data['top_colorscheme_configs'][colorscheme]])
-			except KeyError:
-				pass
+			configs = [
+				(
+					colorscheme,
+					listed_key(data['ext_colorscheme_configs'][ext], colorscheme)
+					+ listed_key(data['ext_colorscheme_configs'][ext], '__main__')
+					+ listed_key(data['top_colorscheme_configs'], colorscheme)
+				)
+			]
 	else:
 		try:
-			configs.append([data['top_colorscheme_configs'][colorscheme]])
+			configs = [(colorscheme, [data['top_colorscheme_configs'][colorscheme]])]
 		except KeyError:
 			pass
-	new_echoerr = DelayedEchoErr(echoerr)
 	hadproblem = False
-	for config_lst in configs:
-		tofind = len(config_lst)
+	for new_colorscheme, config_lst in configs:
 		not_found = []
+		new_data = data.copy()
+		new_data['colorscheme'] = new_colorscheme
 		for config in config_lst:
-			if isinstance(config, tuple):
-				new_colorscheme, config = config
-				new_data = data.copy()
-				new_data['colorscheme'] = new_colorscheme
-			else:
-				new_data = data
 			havemarks(config)
 			try:
 				group_data = config['groups'][group]
@@ -222,21 +228,17 @@ def check_group(group, data, context, echoerr):
 				)
 				if chadproblem:
 					hadproblem = True
-				else:
-					tofind -= 1
-					if not tofind:
-						return proceed, echo, hadproblem
 				if not proceed:
 					break
-		if not_found:
-			new_echoerr(
+		if not_found and len(not_found) == len(config_lst):
+			echoerr(
 				context='Error while checking group definition in colorscheme (key {key})'.format(
 					key=context.key),
-				problem='name {0} is not present in {1} {2} colorschemes: {3}'.format(
-					group, tofind, ext, ', '.join(not_found)),
+				problem='name {0} is not present anywhere in {1} {2} {3} colorschemes: {4}'.format(
+					group, len(not_found), ext, new_colorscheme, ', '.join(not_found)),
 				problem_mark=group.mark
 			)
-	new_echoerr.echo_all()
+			hadproblem = True
 	return True, False, hadproblem
 
 

--- a/powerline/lint/markedjson/error.py
+++ b/powerline/lint/markedjson/error.py
@@ -139,10 +139,10 @@ class Mark:
 		return self.to_string()
 
 
-def echoerr(*args, **kwargs):
+def echoerr(**kwargs):
 	stream = kwargs.pop('stream', sys.stderr)
 	stream.write('\n')
-	stream.write(format_error(*args, **kwargs) + '\n')
+	stream.write(format_error(**kwargs) + '\n')
 
 
 def format_error(context=None, context_mark=None, problem=None, problem_mark=None, note=None):
@@ -180,8 +180,8 @@ class EchoErr(object):
 		self.echoerr = echoerr
 		self.logger = logger
 
-	def __call__(self, *args, **kwargs):
-		self.echoerr(*args, **kwargs)
+	def __call__(self, **kwargs):
+		self.echoerr(**kwargs)
 
 
 class DelayedEchoErr(EchoErr):
@@ -191,12 +191,12 @@ class DelayedEchoErr(EchoErr):
 		super(DelayedEchoErr, self).__init__(echoerr, echoerr.logger)
 		self.errs = []
 
-	def __call__(self, *args, **kwargs):
-		self.errs.append((args, kwargs))
+	def __call__(self, **kwargs):
+		self.errs.append(kwargs)
 
 	def echo_all(self):
-		for args, kwargs in self.errs:
-			self.echoerr(*args, **kwargs)
+		for kwargs in self.errs:
+			self.echoerr(**kwargs)
 
 	def __nonzero__(self):
 		return not not self.errs

--- a/powerline/lint/markedjson/error.py
+++ b/powerline/lint/markedjson/error.py
@@ -138,6 +138,13 @@ class Mark:
 	def __str__(self):
 		return self.to_string()
 
+	def __eq__(self, other):
+		return self is other or (
+			self.name == other.name
+			and self.line == other.line
+			and self.column == other.column
+		)
+
 
 def echoerr(**kwargs):
 	stream = kwargs.pop('stream', sys.stderr)
@@ -154,9 +161,7 @@ def format_error(context=None, context_mark=None, problem=None, problem_mark=Non
 		context_mark is not None
 		and (
 			problem is None or problem_mark is None
-			or context_mark.name != problem_mark.name
-			or context_mark.line != problem_mark.line
-			or context_mark.column != problem_mark.column
+			or context_mark != problem_mark
 		)
 	):
 		lines.append(context_mark.to_string(indent=indent))

--- a/powerline/lint/markedjson/error.py
+++ b/powerline/lint/markedjson/error.py
@@ -145,10 +145,11 @@ def echoerr(**kwargs):
 	stream.write(format_error(**kwargs) + '\n')
 
 
-def format_error(context=None, context_mark=None, problem=None, problem_mark=None, note=None):
+def format_error(context=None, context_mark=None, problem=None, problem_mark=None, note=None, indent=0):
 	lines = []
+	indentstr = ' ' * indent
 	if context is not None:
-		lines.append(context)
+		lines.append(indentstr + context)
 	if (
 		context_mark is not None
 		and (
@@ -158,13 +159,13 @@ def format_error(context=None, context_mark=None, problem=None, problem_mark=Non
 			or context_mark.column != problem_mark.column
 		)
 	):
-		lines.append(str(context_mark))
+		lines.append(context_mark.to_string(indent=indent))
 	if problem is not None:
-		lines.append(problem)
+		lines.append(indentstr + problem)
 	if problem_mark is not None:
-		lines.append(str(problem_mark))
+		lines.append(problem_mark.to_string(indent=indent))
 	if note is not None:
-		lines.append(note)
+		lines.append(indentstr + note)
 	return '\n'.join(lines)
 
 
@@ -174,29 +175,48 @@ class MarkedError(Exception):
 
 
 class EchoErr(object):
-	__slots__ = ('echoerr', 'logger',)
+	__slots__ = ('echoerr', 'logger', 'indent')
 
-	def __init__(self, echoerr, logger):
+	def __init__(self, echoerr, logger, indent=0):
 		self.echoerr = echoerr
 		self.logger = logger
+		self.indent = indent
 
 	def __call__(self, **kwargs):
+		kwargs = kwargs.copy()
+		kwargs.setdefault('indent', self.indent)
 		self.echoerr(**kwargs)
 
 
 class DelayedEchoErr(EchoErr):
-	__slots__ = ('echoerr', 'logger', 'errs')
+	__slots__ = ('echoerr', 'logger', 'errs', 'message', 'separator_message', 'indent', 'indent_shift')
 
-	def __init__(self, echoerr):
+	def __init__(self, echoerr, message='', separator_message=''):
 		super(DelayedEchoErr, self).__init__(echoerr, echoerr.logger)
-		self.errs = []
+		self.errs = [[]]
+		self.message = message
+		self.separator_message = separator_message
+		self.indent_shift = (4 if message or separator_message else 0)
+		self.indent = echoerr.indent + self.indent_shift
 
 	def __call__(self, **kwargs):
-		self.errs.append(kwargs)
+		kwargs = kwargs.copy()
+		kwargs['indent'] = kwargs.get('indent', 0) + self.indent
+		self.errs[-1].append(kwargs)
+
+	def next_variant(self):
+		self.errs.append([])
 
 	def echo_all(self):
-		for kwargs in self.errs:
-			self.echoerr(**kwargs)
+		if self.message:
+			self.echoerr(problem=self.message, indent=(self.indent - self.indent_shift))
+		for variant in self.errs:
+			if not variant:
+				continue
+			if self.separator_message and variant is not self.errs[0]:
+				self.echoerr(problem=self.separator_message, indent=(self.indent - self.indent_shift))
+			for kwargs in variant:
+				self.echoerr(**kwargs)
 
 	def __nonzero__(self):
 		return not not self.errs

--- a/powerline/lint/spec.py
+++ b/powerline/lint/spec.py
@@ -309,11 +309,16 @@ class Spec(object):
 		``self.specs[start:end]`` is matched by the given value.
 		'''
 		havemarks(value)
-		new_echoerr = DelayedEchoErr(echoerr)
+		new_echoerr = DelayedEchoErr(
+			echoerr,
+			'One of the either variants failed. Messages from the first variant:',
+			'messages from the next variant:'
+		)
 
 		hadproblem = False
 		for spec in self.specs[start:end]:
 			proceed, hadproblem = spec.match(value, value.mark, data, context, new_echoerr)
+			new_echoerr.next_variant()
 			if not proceed:
 				break
 			if not hadproblem:


### PR DESCRIPTION
It appears that `warning:regular` group was missing, so email_imap segment did not work (#1323, #1320) and when running under superuser user segment was not highlighted properly.

This PR adds missing highlight groups and also makes sure that `powerline-lint` will be able to catch such problems in the future.