### PR TITLE
Fix warning when &l:statusline is set to a unicode value

### DIFF
--- a/tests/test_foreign_stl_override.vim
+++ b/tests/test_foreign_stl_override.vim
@@ -1,0 +1,22 @@
+scriptencoding utf-8
+set encoding=utf-8
+let g:powerline_config_paths = [expand('<sfile>:p:h:h') . '/powerline/config_files']
+set laststatus=2
+redir => g:messages
+	try
+		source powerline/bindings/vim/plugin/powerline.vim
+		redrawstatus!
+		vsplit
+		redrawstatus!
+		setlocal statusline=«»
+		redrawstatus!
+	catch
+		call writefile(['Unexpected exception', v:exception], 'message.fail')
+		cquit
+	endtry
+redir END
+if g:messages =~# '\v\S'
+	call writefile(['Unexpected messages'] + split(g:messages, "\n", 1), 'message.fail')
+	cquit
+endif
+qall!


### PR DESCRIPTION
This normally should not happen because &l:stl should be powerline-controlled,
but some plugins do this.

Fixes #1347