### PR TITLE
Fix dash bindings on OS X

### DIFF
--- a/powerline/bindings/shell/powerline.sh
+++ b/powerline/bindings/shell/powerline.sh
@@ -66,7 +66,7 @@ _powerline_set_append_trap() {
 
 _powerline_create_temp() {
 	if test -z "$_POWERLINE_TEMP" || ! test -e "$_POWERLINE_TEMP" ; then
-		_POWERLINE_TEMP="$(mktemp)"
+		_POWERLINE_TEMP="$(mktemp "${TMPDIR:-/tmp}/powerline.XXXXXXXX")"
 		_powerline_append_trap 'rm $_POWERLINE_TEMP' EXIT
 	fi
 }
@@ -74,7 +74,7 @@ _powerline_create_temp() {
 _powerline_set_set_jobs() {
 	if _powerline_has_jobs_in_subshell "$@" ; then
 		_powerline_set_jobs() {
-			_POWERLINE_JOBS="$(jobs -p|wc -l)"
+			_POWERLINE_JOBS="$(jobs -p|wc -l|tr -d ' ')"
 		}
 	else
 		_powerline_set_append_trap "$@"
@@ -90,7 +90,7 @@ _powerline_set_set_jobs() {
 			kill -USR1 $_POWERLINE_PID
 			# Note: most likely this will read data from the previous run. Tests 
 			# show that it is OK for some reasons.
-			_POWERLINE_JOBS="$(wc -l < $_POWERLINE_TEMP)"
+			_POWERLINE_JOBS="$(wc -l < $_POWERLINE_TEMP | tr -d ' ')"
 		}
 	fi
 	_powerline_set_set_jobs() {

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -188,6 +188,7 @@ ln -s "$(which mktemp)" tests/shell/path
 ln -s "$(which grep)" tests/shell/path
 ln -s "$(which sed)" tests/shell/path
 ln -s "$(which rm)" tests/shell/path
+ln -s "$(which tr)" tests/shell/path
 ln -s "$(which uname)" tests/shell/path
 ln -s "$(which test)" tests/shell/path
 ln -s "$(which pwd)" tests/shell/path


### PR DESCRIPTION
Fixes two errors that occur while using Powerline with the dash shell under Mac OS X.

**Problem:** Execution of the mktemp command fails.
**Cause:** mktemp requires a mandatory argument on OS X.
**Solution:** Provide a template using the -t option. While it is a deprecated option on Linux, it is still supported and provides compatibility with other systems.

**Problem:** The powerline executable fails to be called because its command line unexpectedly contains spaces.
**Cause:** The _POWERLINE_JOBS variable contains spaces because the wc command returns spaces before the number on OS X.
**Solution:** Trim the spaces before assigning the value to the variable.