### PR TITLE
Switch the underlying i3-IPC layer and deprecate i3bgbar bindings

### DIFF
--- a/docs/source/usage/wm-widgets.rst
+++ b/docs/source/usage/wm-widgets.rst
@@ -51,8 +51,8 @@ Add the following to :file:`~/.config/qtile/config.py`:
 
 .. _bar-usage:
 
-LemonBoy’s bar
-==============
+bar-aint-recursive
+==================
 
 To run the bar simply pipe the output of the binding script into ``bar`` and 
 specify appropriate options, for example like this::
@@ -62,6 +62,9 @@ specify appropriate options, for example like this::
 to run with i3, simply ``exec`` this in i3 config file::
 
     exec python /path/to/powerline/bindings/bar/powerline-bar.py --i3 | bar
+
+Running the binding in i3-mode will require `i3ipc <https://github.com/acrisci/i3ipc-python>`_
+(or the outdated `i3-py <https://github.com/ziberna/i3-py>`_).
 
 See the `bar documentation <https://github.com/LemonBoy/bar>`_ for more 
 information and options.

--- a/powerline/bindings/bar/powerline-bar.py
+++ b/powerline/bindings/bar/powerline-bar.py
@@ -9,7 +9,6 @@ from threading import Lock, Timer
 from argparse import ArgumentParser
 
 from powerline import Powerline
-from powerline.lib.monotonic import monotonic
 from powerline.lib.encoding import get_unicode_writer
 
 
@@ -29,12 +28,12 @@ if __name__ == '__main__':
 	args = parser.parse_args()
 	powerline = BarPowerline()
 	lock = Lock()
-	modes = ["default"]
+	modes = ['default']
 	write = get_unicode_writer(encoding='utf-8')
 
 	def render(reschedule=False):
 		if reschedule:
-			Timer(0.5, render, kwargs={"reschedule": True}).start()
+			Timer(0.5, render, kwargs={'reschedule': True}).start()
 
 		global lock
 		with lock:

--- a/powerline/bindings/bar/powerline-bar.py
+++ b/powerline/bindings/bar/powerline-bar.py
@@ -30,6 +30,7 @@ def render(reschedule=False):
 		write('\n')
 		sys.stdout.flush()
 
+
 if __name__ == '__main__':
 	parser = ArgumentParser(description='Powerline BAR bindings.')
 	parser.add_argument(
@@ -47,11 +48,14 @@ if __name__ == '__main__':
 	if args.i3:
 		try:
 			import i3ipc
-			conn = i3ipc.Connection()
-			conn.on('workspace::focus', lambda conn, evt: render())
-			conn.main()
 		except ImportError:
 			import i3
 			i3.Subscription(lambda evt, data, sub: print(render()), 'workspace')
+		else:
+			conn = i3ipc.Connection()
+			conn.on('workspace::focus', lambda conn, evt: render())
+			conn.on('mode', lambda conn, evt: render())
+			conn.main()
 
-	while True: pass
+	while True:
+		time.sleep(0.5)

--- a/powerline/bindings/bar/powerline-bar.py
+++ b/powerline/bindings/bar/powerline-bar.py
@@ -5,7 +5,7 @@ from __future__ import (unicode_literals, division, absolute_import, print_funct
 import sys
 import time
 
-from threading import Lock
+from threading import Lock, Timer
 from argparse import ArgumentParser
 
 from powerline import Powerline
@@ -20,13 +20,15 @@ class BarPowerline(Powerline):
 		super(BarPowerline, self).init(ext='wm', renderer_module='bar')
 
 
-def render(event=None, data=None, sub=None):
+def render(reschedule=False):
+	if reschedule:
+		Timer(0.5, render, kwargs={"reschedule": True}).start()
+
 	global lock
 	with lock:
 		write(powerline.render())
 		write('\n')
 		sys.stdout.flush()
-
 
 if __name__ == '__main__':
 	parser = ArgumentParser(description='Powerline BAR bindings.')
@@ -37,16 +39,19 @@ if __name__ == '__main__':
 	args = parser.parse_args()
 	powerline = BarPowerline()
 
-	interval = 0.5
 	lock = Lock()
 
 	write = get_unicode_writer(encoding='utf-8')
+	render(reschedule=True)
 
 	if args.i3:
-		import i3
-		sub = i3.Subscription(render, 'workspace')
+		try:
+			import i3ipc
+			conn = i3ipc.Connection()
+			conn.on('workspace::focus', lambda conn, evt: render())
+			conn.main()
+		except ImportError:
+			import i3
+			i3.Subscription(lambda evt, data, sub: print(render()), 'workspace')
 
-	while True:
-		start_time = monotonic()
-		render()
-		time.sleep(max(interval - (monotonic() - start_time), 0.1))
+	while True: pass

--- a/powerline/bindings/bar/powerline-bar.py
+++ b/powerline/bindings/bar/powerline-bar.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 	args = parser.parse_args()
 	powerline = BarPowerline()
 	lock = Lock()
-	modes = [None]
+	modes = ["default"]
 	write = get_unicode_writer(encoding='utf-8')
 
 	def render(reschedule=False):

--- a/powerline/renderers/bar.py
+++ b/powerline/renderers/bar.py
@@ -35,10 +35,10 @@ class BarRenderer(Renderer):
 
 		return text + contents + '%{F-B--u}'
 
-	def render(self):
+	def render(self, *args, **kwargs):
 		return '%{{l}}{0}%{{r}}{1}'.format(
-			super(BarRenderer, self).render(side='left'),
-			super(BarRenderer, self).render(side='right'),
+			super(BarRenderer, self).render(side='left', *args, **kwargs),
+			super(BarRenderer, self).render(side='right', *args, **kwargs),
 		)
 
 

--- a/powerline/segments/i3wm.py
+++ b/powerline/segments/i3wm.py
@@ -1,7 +1,11 @@
 # vim:fileencoding=utf-8:noet
 from __future__ import (unicode_literals, division, absolute_import, print_function)
 
-import i3
+conn = None
+try:
+    import i3ipc
+except ImportError:
+    import i3 as conn
 
 
 def calcgrp(w):
@@ -16,12 +20,19 @@ def calcgrp(w):
 	return group
 
 
-def workspaces(pl):
-	'''Return workspace list
+def workspaces(pl, strip=0):
+	'''Return list of used workspaces
+
+	:param int strip:
+		Specifies how many characters from the front of each workspace name should
+		be stripped (e.g. to remove workspace numbers). Defaults to zero.
 
 	Highlight groups used: ``workspace``, ``w_visible``, ``w_focused``, ``w_urgent``
 	'''
+	global conn
+	if not conn: conn = i3ipc.Connection()
+
 	return [{
-		'contents': w['name'],
+		'contents': w['name'][min(len(w['name']),strip):],
 		'highlight_groups': calcgrp(w)
-	} for w in i3.get_workspaces()]
+	} for w in conn.get_workspaces()]

--- a/powerline/segments/i3wm.py
+++ b/powerline/segments/i3wm.py
@@ -1,10 +1,7 @@
 # vim:fileencoding=utf-8:noet
 from __future__ import (unicode_literals, division, absolute_import, print_function)
 
-from threading import Thread
-
 from powerline.theme import requires_segment_info
-from powerline.segments import Segment, with_docstring
 
 
 conn = None
@@ -30,27 +27,28 @@ def workspaces(pl, only_show=None, strip=0):
 	'''Return list of used workspaces
 
 	:param list only_show:
-		Specifies which workspaces to show.
-		Valid entries are "visible", "urgent" and "focused".
-		If omitted or ``null`` all workspaces are shown.
+		Specifies which workspaces to show. Valid entries are ``"visible"``, 
+		``"urgent"`` and ``"focused"``. If omitted or ``null`` all workspaces 
+		are shown.
 
 	:param int strip:
-		Specifies how many characters from the front of each workspace name should
-		be stripped (e.g. to remove workspace numbers). Defaults to zero.
+		Specifies how many characters from the front of each workspace name 
+		should be stripped (e.g. to remove workspace numbers). Defaults to zero.
 
-	Highlight groups used: ``workspace``, ``w_visible``, ``w_focused``, ``w_urgent``
+	Highlight groups used: ``workspace`` or ``w_visible``, ``workspace`` or ``w_focused``, ``workspace`` or ``w_urgent``.
 	'''
 	global conn
-	if not conn: conn = i3ipc.Connection()
+	if not conn:
+		conn = i3ipc.Connection()
 
 	return [{
-		'contents': w['name'][min(len(w['name']),strip):],
+		'contents': w['name'][min(len(w['name']), strip):],
 		'highlight_groups': calcgrp(w)
-	} for w in conn.get_workspaces() if not only_show or any(w[typ] for typ in only_show)]
+	} for w in conn.get_workspaces() if not only_show or any((w[typ] for typ in only_show))]
 
 
 @requires_segment_info
-def mode(pl, segment_info, names={"default": None}):
+def mode(pl, segment_info, names={'default': None}):
 	'''Returns current i3 mode
 
 	:param dict names:

--- a/powerline/segments/i3wm.py
+++ b/powerline/segments/i3wm.py
@@ -5,10 +5,6 @@ from powerline.theme import requires_segment_info
 
 
 conn = None
-try:
-    import i3ipc
-except ImportError:
-    import i3 as conn
 
 
 def calcgrp(w):
@@ -39,7 +35,12 @@ def workspaces(pl, only_show=None, strip=0):
 	'''
 	global conn
 	if not conn:
-		conn = i3ipc.Connection()
+		try:
+			import i3ipc
+		except ImportError:
+			import i3 as conn
+		else:
+			conn = i3ipc.Connection()
 
 	return [{
 		'contents': w['name'][min(len(w['name']), strip):],

--- a/powerline/segments/i3wm.py
+++ b/powerline/segments/i3wm.py
@@ -1,6 +1,11 @@
 # vim:fileencoding=utf-8:noet
 from __future__ import (unicode_literals, division, absolute_import, print_function)
 
+from threading import Thread
+
+from powerline.segments import Segment, with_docstring
+
+
 conn = None
 try:
     import i3ipc
@@ -36,3 +41,32 @@ def workspaces(pl, strip=0):
 		'contents': w['name'][min(len(w['name']),strip):],
 		'highlight_groups': calcgrp(w)
 	} for w in conn.get_workspaces()]
+
+class ModeSegment(Segment):
+	def startup(self, pl, shutdown_event):
+		self.mode = 'default'
+
+		def callback(conn, e):
+			self.mode = e.change
+
+		conn = i3ipc.Connection()
+		conn.on('mode', callback)
+		self.thread = Thread(target=conn.main)
+		self.thread.daemon = True
+		self.thread.start()
+
+	def __call__(self, pl, default=None):
+		if self.mode == 'default':
+			return default
+		return self.mode
+
+
+mode = with_docstring(ModeSegment(),
+'''Returns the current i3 mode
+
+:param str default:
+	Specifies the name to be displayed instead of "default".
+	By default the segment is left out in the default mode.
+
+Highligh groups used: ``mode``
+''')


### PR DESCRIPTION
Replaces #1366 which contains at least one error (Python-2.6 does not support `func(expr for i in iterable)`: need more parenthesis) and a number of style mistakes.

Provided tests should’ve catched the error if it was not fixed in c02516a4437c0d94f6585dce65ca349c6b399120.