### PR TITLE
Use psutil.boot_time() function if appropriate

### DIFF
--- a/powerline/segments/common/sys.py
+++ b/powerline/segments/common/sys.py
@@ -131,10 +131,12 @@ if os.path.exists('/proc/uptime'):
 elif 'psutil' in globals():
 	from time import time
 
-	def _get_uptime():
-		# psutil.BOOT_TIME is not subject to clock adjustments, but time() is.
-		# Thus it is a fallback to /proc/uptime reading and not the reverse.
-		return int(time() - psutil.BOOT_TIME)
+	if hasattr(psutil, 'boot_time'):
+		def _get_uptime():
+			return int(time() - psutil.boot_time())
+	else:
+		def _get_uptime():
+			return int(time() - psutil.BOOT_TIME)
 else:
 	def _get_uptime():
 		raise NotImplementedError


### PR DESCRIPTION
It now replaced psutil.BOOT_TIME attribute.

Fixes #1391