### PR TITLE
Do not use tcsh, mksh, busybox and socat from deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ addons:
             - libssl1.0.0
             - zsh
             - tcsh
-            # - mksh
-            # - busybox
+            - mksh
+            - busybox
             # - rc
-            # - socat
+            - socat
             - bc
 language: python
 install: tests/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
         packages:
             - libssl1.0.0
             - zsh
-            # - tcsh
+            - tcsh
             # - mksh
             # - busybox
             # - rc

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -13,7 +13,6 @@ if test "$TRAVIS" = true ; then
 	export PATH="$PWD/tests/bot-ci/deps/rc:$PATH"
 	export PATH="$PWD/tests/bot-ci/deps/mksh:$PATH"
 	export PATH="$PWD/tests/bot-ci/deps/busybox:$PATH"
-	export PATH="$PWD/tests/bot-ci/deps/tcsh:$PATH"
 	export PATH="$PWD/tests/bot-ci/deps/socat:$PATH"
 
 	if test "$PYTHON_IMPLEMENTATION" = "CPython" ; then

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,9 +11,6 @@ FAILED=0
 if test "$TRAVIS" = true ; then
 	export PATH="$HOME/opt/fish/bin:${PATH}"
 	export PATH="$PWD/tests/bot-ci/deps/rc:$PATH"
-	export PATH="$PWD/tests/bot-ci/deps/mksh:$PATH"
-	export PATH="$PWD/tests/bot-ci/deps/busybox:$PATH"
-	export PATH="$PWD/tests/bot-ci/deps/socat:$PATH"
 
 	if test "$PYTHON_IMPLEMENTATION" = "CPython" ; then
 		export PATH="$HOME/opt/zsh-${PYTHON_MM}${USE_UCS2_PYTHON:+-ucs2}/bin:${PATH}"


### PR DESCRIPTION
All of them were whitelisted:
- Tcsh was whitelisted in travis-ci/travis-ci#3882.
- Mksh was whitelisted in travis-ci/travis-ci#3881.
- Busybox was whitelisted in travis-ci/travis-ci#3880.
- Socat was whitelisted in travis-ci/travis-ci#3883.