### PR TITLE
Added tips for Urxvt compiler flags

### DIFF
--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -189,6 +189,25 @@ If your locale encoding is not unicode (any encoding that starts with “utf” 
 should set up your system to use unicode locale or forget about powerline fancy 
 characters.
 
+Urxvt unicode3 and frills
+-------------------------
+
+Make sure that, whatever urxvt package you're installing, both the `unicode3`
+and `frills` features are enabled at compile time. Run
+``urxvt --help 2>&1 | grep options:`` to get a list of enabled options.
+This should contain at least `frills`, `unicode3` and optionally `iso14755`
+if you want to input Unicode characters as well.
+
+Compiler flags example:
+
+    --enable-frills \
+    --enable-unicode3
+
+As long as your terminal emulator is compiled without unicode rendering,
+no amount of configuration will make it display unicode characters.
+They're being considered 'unnecessary features', but they add negligible
+overhead to the size of the installed package (~100KB).
+
 Vim issues
 ==========
 


### PR DESCRIPTION
In regards to #684 , this might be useful to have in the tips & tricks.

Apparently, my editor also trimmed some whitespace, sorry about that. ;)