### PR TITLE
Fix manpage generation with python3

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,8 +1,8 @@
 # Makefile for Sphinx documentation
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
-BUILDDIR      = _build
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+PAPER         ?=
+BUILDDIR      ?= _build
 
 # Internal variables
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/docs/source/powerline_automan.py
+++ b/docs/source/powerline_automan.py
@@ -7,6 +7,8 @@ import codecs
 
 from collections import namedtuple
 
+from functools import reduce
+
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import unchanged_required
 from docutils import nodes


### PR DESCRIPTION
Fix manpage generation with Python 3 and allow packagers to select which version of sphinx-build (python2 ou 3) they want to use. Fixes issue #1388.