### PR TITLE
Adds feature hide_domain (requested in #1420)

### DIFF
--- a/powerline/segments/common/env.py
+++ b/powerline/segments/common/env.py
@@ -148,11 +148,13 @@ username = False
 _geteuid = getattr(os, 'geteuid', lambda: 1)
 
 
-def user(pl, hide_user=None):
+def user(pl, hide_user=None, hide_domain=False):
 	'''Return the current user.
 
 	:param str hide_user:
 		Omit showing segment for users with names equal to this string.
+	:param bool hide_domain:
+		Drop domain component if it exists in a username (delimited by '@').
 
 	Highlights the user with the ``superuser`` if the effective user ID is 0.
 
@@ -166,6 +168,11 @@ def user(pl, hide_user=None):
 		return None
 	if username == hide_user:
 		return None
+	if hide_domain == True:
+		try:
+			username = username[:username.index('@')]
+		except ValueError:
+			pass
 	euid = _geteuid()
 	return [{
 		'contents': username,

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -472,15 +472,15 @@ class TestEnv(TestCommon):
 				pass
 
 			def username(self):
-				return 'def'
+				return 'def@DOMAIN.COM'
 
 			if hasattr(self.module, 'psutil') and not callable(self.module.psutil.Process.username):
 				username = property(username)
 
 		struct_passwd = namedtuple('struct_passwd', ('pw_name',))
 		new_psutil = new_module('psutil', Process=Process)
-		new_pwd = new_module('pwd', getpwuid=lambda uid: struct_passwd(pw_name='def'))
-		new_getpass = new_module('getpass', getuser=lambda: 'def')
+		new_pwd = new_module('pwd', getpwuid=lambda uid: struct_passwd(pw_name='def@DOMAIN.COM'))
+		new_getpass = new_module('getpass', getuser=lambda: 'def@DOMAIN.COM')
 		pl = Pl()
 		with replace_attr(self.module, 'pwd', new_pwd):
 			with replace_attr(self.module, 'getpass', new_getpass):
@@ -488,12 +488,18 @@ class TestEnv(TestCommon):
 					with replace_attr(self.module, 'psutil', new_psutil):
 						with replace_attr(self.module, '_geteuid', lambda: 5):
 							self.assertEqual(self.module.user(pl=pl), [
-								{'contents': 'def', 'highlight_groups': ['user']}
+								{'contents': 'def@DOMAIN.COM', 'highlight_groups': ['user']}
 							])
 							self.assertEqual(self.module.user(pl=pl, hide_user='abc'), [
+								{'contents': 'def@DOMAIN.COM', 'highlight_groups': ['user']}
+							])
+							self.assertEqual(self.module.user(pl=pl, hide_domain=False), [
+								{'contents': 'def@DOMAIN.COM', 'highlight_groups': ['user']}
+							])
+							self.assertEqual(self.module.user(pl=pl, hide_user='def@DOMAIN.COM'), None)
+							self.assertEqual(self.module.user(pl=pl, hide_domain=True), [
 								{'contents': 'def', 'highlight_groups': ['user']}
 							])
-							self.assertEqual(self.module.user(pl=pl, hide_user='def'), None)
 						with replace_attr(self.module, '_geteuid', lambda: 0):
 							self.assertEqual(self.module.user(pl=pl), [
 								{'contents': 'def', 'highlight_groups': ['superuser', 'user']}


### PR DESCRIPTION
Set "hide_domain" to true in powerline.segments.common.env.user in
your shell theme json to hide the domain component of a username
(ex, "user@DOMAIN.COM" becomes just "user".)

Tests have been added, too, but an adult may want to double check
them.