### PR TITLE
Add option to detect internal_ip interface from default gateway

### DIFF
--- a/powerline/segments/common/net.py
+++ b/powerline/segments/common/net.py
@@ -118,6 +118,7 @@ else:
 		try:
 			return addrs[family][0]['addr']
 		except (KeyError, IndexError):
+			pl.info("No IPv{0} address found for interface {1}", ipv, interface)
 			return None
 
 

--- a/powerline/segments/common/net.py
+++ b/powerline/segments/common/net.py
@@ -101,15 +101,22 @@ else:
 			return 0
 
 	def internal_ip(pl, interface='auto', ipv=4):
+		family = netifaces.AF_INET6 if ipv == 6 else netifaces.AF_INET
 		if interface == 'auto':
 			try:
 				interface = next(iter(sorted(netifaces.interfaces(), key=_interface_key, reverse=True)))
 			except StopIteration:
 				pl.info('No network interfaces found')
 				return None
+		elif interface == 'default_gateway':
+			try:
+				interface = netifaces.gateways()['default'][family][1]
+			except KeyError:
+				pl.info('No default gateway found for IPv{0}', ipv)
+				return None
 		addrs = netifaces.ifaddresses(interface)
 		try:
-			return addrs[netifaces.AF_INET6 if ipv == 6 else netifaces.AF_INET][0]['addr']
+			return addrs[family][0]['addr']
 		except (KeyError, IndexError):
 			return None
 
@@ -130,6 +137,11 @@ Requires ``netifaces`` module to work properly.
 	#. ``teredo`` followed by number or the end of string.
 	#. Any other interface that is not ``lo*``.
 	#. ``lo`` followed by number or the end of string.
+
+	Use ``default_gateway`` to detect the interface based on the machine's
+	`default gateway <https://en.wikipedia.org/wiki/Default_gateway>`_ (i.e.,
+	the router to which it is connected).
+
 :param int ipv:
 	4 or 6 for ipv4 and ipv6 respectively, depending on which IP address you 
 	need exactly.


### PR DESCRIPTION
This pull requests adds the option to specify `interface='default_gateway'` to the `internal_ip` segment. This displays the IP address of the interface connected to the [default gateway](https://en.wikipedia.org/wiki/Default_gateway).

**Motivation:** I own a MacBook Pro running OS X. Sometimes I am connected to the Internet via Ethernet (interface `en0`), other times via wireless (interface `en1`). Either way, I want to see the IPv4 address of the interface through which my Internet traffic is going.

**Details:** The default behavior for OS X is that IPv4 addresses are configured through DHCP, and only assigned if the interface is connected. But IPv6 addresses are assigned through [stateless address autoconfiguration](https://en.wikipedia.org/wiki/IPv6#Stateless_address_autoconfiguration_.28SLAAC.29) for both interfaces, no matter if they are connected. After adding `en` to the list of recognized interfaces, `interface='auto'` always selects `en0` (being the lowest-numbered), then does not display the segment when I am connected via wireless as `en0` does not have an IPv4 address. Selecting the interface based on the default gateway, however, yields my preferred results, and I also think this behavior would be useful to others.

Feel free to cherry pick to leave out the commit that adds an extra log message. I added it because I found it useful in my debugging, and `INFO` messages are not logged by default anyway.

Thanks!