### PR TITLE
Show conda environment in virtualenv segment.

### DIFF
--- a/powerline/segments/common/env.py
+++ b/powerline/segments/common/env.py
@@ -19,9 +19,20 @@ def environment(pl, segment_info, variable=None):
 
 
 @requires_segment_info
-def virtualenv(pl, segment_info):
-	'''Return the name of the current Python virtualenv.'''
-	return os.path.basename(segment_info['environ'].get('VIRTUAL_ENV', '')) or None
+def virtualenv(pl, segment_info, ignore_venv=False, ignore_conda=False):
+	'''Return the name of the current Python or conda virtualenv.
+
+	:param bool ignore_venv:
+		Whether to ignore virtual environments. Default is False.
+	:param bool ignore_conda:
+		Whether to ignore conda environments. Default is False.
+	'''
+	return (
+		(not ignore_venv and
+		 os.path.basename(segment_info['environ'].get('VIRTUAL_ENV', ''))) or
+		(not ignore_conda and
+		 segment_info['environ'].get('CONDA_DEFAULT_ENV', '')) or
+		None)
 
 
 @requires_segment_info

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -625,8 +625,39 @@ class TestEnv(TestCommon):
 		pl = Pl()
 		with replace_env('VIRTUAL_ENV', '/abc/def/ghi') as segment_info:
 			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info), 'ghi')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_conda=True), 'ghi')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True, ignore_conda=True), None)
+
 			segment_info['environ'].pop('VIRTUAL_ENV')
 			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_conda=True), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True, ignore_conda=True), None)
+
+		with replace_env('CONDA_DEFAULT_ENV', 'foo') as segment_info:
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info), 'foo')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_conda=True), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True), 'foo')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True, ignore_conda=True), None)
+
+			segment_info['environ'].pop('CONDA_DEFAULT_ENV')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_conda=True), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True, ignore_conda=True), None)
+
+		with replace_env('CONDA_DEFAULT_ENV', 'foo', environ={'VIRTUAL_ENV': '/sbc/def/ghi'}) as segment_info:
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info), 'ghi')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_conda=True), 'ghi')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True), 'foo')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True, ignore_conda=True), None)
+
+			segment_info['environ'].pop('CONDA_DEFAULT_ENV')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info), 'ghi')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_conda=True), 'ghi')
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True), None)
+			self.assertEqual(self.module.virtualenv(pl=pl, segment_info=segment_info, ignore_venv=True, ignore_conda=True), None)
 
 	def test_environment(self):
 		pl = Pl()


### PR DESCRIPTION
Conda environments are pretty much the same as virtualenvs, so I just added a check for them there. One could put it in a separate segment, but I think it fits naturally here.