### PR TITLE
Make date segments work with non-ascii characters in the format string.

### DIFF
--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -17,7 +17,7 @@ def date(pl, format='%Y-%m-%d', istime=False):
 	Highlight groups used: ``time`` or ``date``.
 	'''
 	return [{
-		'contents': datetime.now().strftime(format),
+		'contents': datetime.now().strftime(format.encode('utf-8')).decode('utf-8'),
 		'highlight_groups': (['time'] if istime else []) + ['date'],
 		'divider_highlight_group': 'time:divider' if istime else None,
 	}]
@@ -33,7 +33,7 @@ def fuzzy_time(pl, unicode_text=False):
 	'''Display the current time as fuzzy time, e.g. "quarter past six".
 
 	:param bool unicode_text:
-		If true then hyphenminuses (regular ASCII ``-``) and single quotes are 
+		If true then hyphenminuses (regular ASCII ``-``) and single quotes are
 		replaced with unicode dashes and apostrophes.
 	'''
 	hour_str = ['twelve', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven']

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -19,7 +19,7 @@ def date(pl, format='%Y-%m-%d', istime=False):
 	try:
 		contents = datetime.now().strftime(format)
 	except UnicodeEncodeError:
-		contents = datetime.now().strftime(format.encode('utf-8'))
+		contents = datetime.now().strftime(format.encode('utf-8')).decode('utf-8')
 
 	return [{
 		'contents': contents,

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -16,8 +16,13 @@ def date(pl, format='%Y-%m-%d', istime=False):
 
 	Highlight groups used: ``time`` or ``date``.
 	'''
+	try:
+		contents=datetime.now().strftime(format)
+	except UnicodeEncodeError:
+		contents=datetime.now().strftime(format.encode('utf-8'))
+
 	return [{
-		'contents': datetime.now().strftime(format.encode('utf-8')).decode('utf-8'),
+		'contents': contents,
 		'highlight_groups': (['time'] if istime else []) + ['date'],
 		'divider_highlight_group': 'time:divider' if istime else None,
 	}]

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -17,9 +17,9 @@ def date(pl, format='%Y-%m-%d', istime=False):
 	Highlight groups used: ``time`` or ``date``.
 	'''
 	try:
-		contents=datetime.now().strftime(format)
+		contents = datetime.now().strftime(format)
 	except UnicodeEncodeError:
-		contents=datetime.now().strftime(format.encode('utf-8'))
+		contents = datetime.now().strftime(format.encode('utf-8'))
 
 	return [{
 		'contents': contents,
@@ -38,7 +38,7 @@ def fuzzy_time(pl, unicode_text=False):
 	'''Display the current time as fuzzy time, e.g. "quarter past six".
 
 	:param bool unicode_text:
-		If true then hyphenminuses (regular ASCII ``-``) and single quotes are
+		If true then hyphenminuses (regular ASCII ``-``) and single quotes are 
 		replaced with unicode dashes and apostrophes.
 	'''
 	hour_str = ['twelve', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven']

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -709,7 +709,7 @@ class TestTime(TestCommon):
 		with replace_attr(self.module, 'datetime', Args(now=lambda: Args(strftime=lambda fmt: fmt))):
 			self.assertEqual(self.module.date(pl=pl), [{'contents': '%Y-%m-%d', 'highlight_groups': ['date'], 'divider_highlight_group': None}])
 			self.assertEqual(self.module.date(pl=pl, format='%H:%M', istime=True), [{'contents': '%H:%M', 'highlight_groups': ['time', 'date'], 'divider_highlight_group': 'time:divider'}])
-		self.module.date(pl=pl, format='\u231a')
+		self.assertEqual(self.module.date(pl=pl, format='\u231a', istime=True), [{'contents': '\u231a', 'highlight_groups': ['time', 'date'], 'divider_highlight_group': 'time:divider'}])
 
 	def test_fuzzy_time(self):
 		time = Args(hour=0, minute=45)

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -709,7 +709,7 @@ class TestTime(TestCommon):
 		with replace_attr(self.module, 'datetime', Args(now=lambda: Args(strftime=lambda fmt: fmt))):
 			self.assertEqual(self.module.date(pl=pl), [{'contents': '%Y-%m-%d', 'highlight_groups': ['date'], 'divider_highlight_group': None}])
 			self.assertEqual(self.module.date(pl=pl, format='%H:%M', istime=True), [{'contents': '%H:%M', 'highlight_groups': ['time', 'date'], 'divider_highlight_group': 'time:divider'}])
-		self.module.date(pl=pl, format=u'\u231a')
+		self.module.date(pl=pl, format='\u231a')
 
 	def test_fuzzy_time(self):
 		time = Args(hour=0, minute=45)

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -709,6 +709,7 @@ class TestTime(TestCommon):
 		with replace_attr(self.module, 'datetime', Args(now=lambda: Args(strftime=lambda fmt: fmt))):
 			self.assertEqual(self.module.date(pl=pl), [{'contents': '%Y-%m-%d', 'highlight_groups': ['date'], 'divider_highlight_group': None}])
 			self.assertEqual(self.module.date(pl=pl, format='%H:%M', istime=True), [{'contents': '%H:%M', 'highlight_groups': ['time', 'date'], 'divider_highlight_group': 'time:divider'}])
+		self.module.date(pl=pl, format=u'\u231a')
 
 	def test_fuzzy_time(self):
 		time = Args(hour=0, minute=45)


### PR DESCRIPTION
Enables fancy glyphs in the date segment
```json
"powerline.segments.common.time.date": { 
    "args": { "format": "%F ⌚ %T" } 
} 
```
![image](https://cloud.githubusercontent.com/assets/1686266/10269978/c1ac87ec-6ae4-11e5-86b4-bae34de41bd5.png)

This solves a bug where unicode characters in the format string would cause a UnicodeEncodeError.
```
UnicodeEncodeError: 'ascii' codec can't encode character
u'\u231a' in position 3: ordinal not in range(128)
```