### PR TITLE
Fix typo (missing letter) in installation/osx.rst

### DIFF
--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -22,7 +22,7 @@ Python package
       to be installed. ``coreutils`` may be installed using ``brew install 
       coreutils``.
 
-2. Install Powerline using one of the following commans:
+2. Install Powerline using one of the following commands:
 
    .. code-block:: sh
 


### PR DESCRIPTION
Closes #1463