### PR TITLE
Support tmux-2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,5 @@ matrix:
           env: >-
             USE_UCS2_PYTHON=1
             UCS2_PYTHON_VARIANT="2.7"
-    allow_failures:
-        - python: "2.6"
-          env: >-
-            USE_UCS2_PYTHON=1
-            UCS2_PYTHON_VARIANT="2.6"
 
 # vim: et

--- a/docs/source/develop/segments.rst
+++ b/docs/source/develop/segments.rst
@@ -467,7 +467,8 @@ Shell
 
         ``client_id``
             Identifier unique to one shell instance. Is used to record instance 
-            state by powerline daemon.
+            state by powerline daemon. In tmux this is the same as :ref:`pane_id 
+            <dev-seginfo-shell-renarg-pane_id>`.
 
             It is not guaranteed that existing client ID will not be retaken 
             when old shell with this ID quit: usually process PID is used as 
@@ -480,6 +481,14 @@ Shell
         ``local_theme``
             Local theme that will be used by shell. One should not rely on the 
             existence of this key.
+
+        .. _dev-seginfo-shell-renarg-pane_id:
+
+        ``pane_id``
+            Identifier unique to each tmux pane. Is always an integer, optional. 
+            Obtained by using ``tmux display -p '#D'``, then all leading spaces 
+            and per cent signs are stripped and the result is converted into an 
+            integer.
 
         Other keys, if any, are specific to segments.
 

--- a/powerline/commands/main.py
+++ b/powerline/commands/main.py
@@ -10,7 +10,7 @@ from itertools import chain
 from powerline.lib.overrides import parsedotval, parse_override_var
 from powerline.lib.dict import mergeargs
 from powerline.lib.encoding import get_preferred_arguments_encoding
-from powerline.lib.unicode import u
+from powerline.lib.unicode import u, unicode
 
 
 if sys.version_info < (3,):
@@ -49,6 +49,14 @@ def finish_args(environ, args):
 	))
 	if args.renderer_arg:
 		args.renderer_arg = mergeargs((parsedotval(v) for v in args.renderer_arg), remove=True)
+		if 'pane_id' in args.renderer_arg:
+			if isinstance(args.renderer_arg['pane_id'], (bytes, unicode)):
+				try:
+					args.renderer_arg['pane_id'] = int(args.renderer_arg['pane_id'].lstrip(' %'))
+				except ValueError:
+					pass
+			if 'client_id' not in args.renderer_arg:
+				args.renderer_arg['client_id'] = args.renderer_arg['pane_id']
 	args.config_path = (
 		[path for path in environ.get('POWERLINE_CONFIG_PATHS', '').split(':') if path]
 		+ (args.config_path or [])

--- a/powerline/renderers/tmux.py
+++ b/powerline/renderers/tmux.py
@@ -63,7 +63,7 @@ class TmuxRenderer(Renderer):
 		if segment_info:
 			r.update(segment_info)
 		if 'pane_id' in r:
-			varname = 'TMUX_PWD_' + r['pane_id'].lstrip('% ')
+			varname = 'TMUX_PWD_' + str(r['pane_id'])
 			if varname in r['environ']:
 				r['getcwd'] = lambda: r['environ'][varname]
 		r['mode'] = mode

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -29,7 +29,11 @@ checkout_cached_dir git://github.com/powerline/deps tests/bot-ci/deps
 mkdir -p "$HOME/opt"
 
 if test -n "$USE_UCS2_PYTHON" ; then
-	pip install virtualenvwrapper
+	if test "$UCS2_PYTHON_VARIANT" = "2.6" ; then
+		pip install 'virtualenvwrapper==4.6.0'
+	else
+		pip install virtualenvwrapper
+	fi
 	set +e
 	. virtualenvwrapper.sh
 	set -e


### PR DESCRIPTION
Tmux-2.1 appears not to output leading `%` when using `tmux display -p '#D'`. 
This change changes type of the `pane_id` argument: leading `%` turns it into 
a literal string, number in front makes it be parsed as a JSON number.

Fixes #1470