### PR TITLE
Include dist folder to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include powerline *.json *.vim
 recursive-include powerline/bindings *.*
 recursive-exclude powerline/bindings *.pyc *.pyo
+recursive-include powerline/dist *.*
 recursive-include client *.*
 recursive-include docs/source *.rst *.py
 include docs/Makefile


### PR DESCRIPTION
As introduced in #1449 a systemd's `.service` file was included in `dist/systemd`.
However this folder was not included in `MANIFEST.in`.