### PR TITLE
Tabline and bufferlister updates

### DIFF
--- a/powerline/config_files/colorschemes/vim/__main__.json
+++ b/powerline/config_files/colorschemes/vim/__main__.json
@@ -23,15 +23,24 @@
 		"csv:column_number": "line_current",
 		"csv:column_name":   "line_current_symbol",
 
+		"tab:background":     "background",
+		"tab:divider":        "background:divider",
+
 		"tab_nc:modified_indicator": "modified_indicator",
 		"tab_nc:file_directory":     "information:unimportant",
 		"tab_nc:file_name":          "tab_nc:file_directory",
 		"tab_nc:tabnr":              "tab_nc:file_directory",
 
 		"buf_nc:file_directory":     "tab_nc:file_directory",
-		"buf_nc:file_name":          "tab_nc:file_name",
-		"buf_nc:bufnr":              "tab_nc:tabnr",
+		"buf_nc:file_name":          "buf_nc:file_directory",
+		"buf_nc:bufnr":              "buf_nc:file_directory",
 		"buf_nc:modified_indicator": "tab_nc:modified_indicator",
+
+		"buf_nc_mod:file_directory":     "tab_nc:file_directory",
+		"buf_nc_mod:file_name":          "buf_nc_mod:file_directory",
+		"buf_nc_mod:bufnr":              "buf_nc_mod:file_directory",
+		"buf_nc_mod:modified_indicator": "tab_nc:modified_indicator",
+
 
 		"commandt:label":      "file_name",
 		"commandt:background": "background",

--- a/powerline/config_files/themes/vim/tabline.json
+++ b/powerline/config_files/themes/vim/tabline.json
@@ -67,7 +67,7 @@
 			},
 			{
 				"type": "string",
-				"highlight_groups": ["background"],
+				"highlight_groups": ["tab:background"],
 				"draw_soft_divider": false,
 				"draw_hard_divider": false,
 				"width": "auto"

--- a/powerline/listers/vim.py
+++ b/powerline/listers/vim.py
@@ -89,22 +89,13 @@ def bufferlister(pl, segment_info, show_unlisted=False, **kwargs):
 		return dct
 
 	return (
-		(
-			buf_segment_info,
-			add_multiplier(buf_segment_info['buffer'], {'highlight_group_prefix': prefix})
-		)
-		for buf_segment_info, prefix in (
-			(
-				buffer_updated_segment_info(
-					segment_info,
-					buffer
-				),
-				('buf' if buffer is cur_buffer else 'buf_nc')
-			)
-			for buffer in vim.buffers
-		) if (
-			buf_segment_info['buffer'] is cur_buffer
-			or show_unlisted
-			or int(vim_getbufoption(buf_segment_info, 'buflisted'))
+		(lambda buffer, prefix: (
+			buffer_updated_segment_info(segment_info, buffer),
+			add_multiplier(buffer, {'highlight_group_prefix': prefix}
+		))(buffer, 'buf' if buffer is cur_buffer else 'buf_nc')
+		for buffer in vim.buffers if (
+		    buffer is cur_buffer
+		    or show_unlisted
+		    or int(vim.eval('buflisted(%s)' % buffer.number)) > 0
 		)
 	)

--- a/powerline/listers/vim.py
+++ b/powerline/listers/vim.py
@@ -102,7 +102,7 @@ def bufferlister(pl, segment_info, show_unlisted=False, **kwargs):
 		))(
 			buffer,
 			'buf' if buffer is cur_buffer else 'buf_nc',
-			'_mod' if int(vim.eval('getbufvar(%s, \'&mod\')' % buffer.number)) > 0 else ''
+			'_mod' if int(vim.eval('getbufvar(%s, \'&modified\')' % buffer.number)) > 0 else ''
 		)
 		for buffer in vim.buffers if (
 		    buffer is cur_buffer

--- a/tests/test_tabline.vim
+++ b/tests/test_tabline.vim
@@ -16,7 +16,7 @@ catch
 	cquit
 endtry
 
-if result isnot# '%1T%#Pl_247_10395294_236_3158064_NONE# 1 ./abc  %2T2 ./def %#Pl_236_3158064_240_5789784_NONE# %3T%#Pl_250_12369084_240_5789784_NONE#3 ./%#Pl_231_16777215_240_5789784_bold#ghi %#Pl_240_5789784_236_3158064_NONE# %T%#Pl_231_16777215_236_3158064_NONE#                                         %#Pl_252_13684944_236_3158064_NONE# %#Pl_235_2500134_252_13684944_bold# Tabs '
+if result isnot# '%1T%#Pl_247_10395294_236_3158064_NONE# 1 ./abc %#Pl_244_8421504_236_3158064_NONE# %2T%#Pl_247_10395294_236_3158064_NONE#2 ./def %#Pl_236_3158064_240_5789784_NONE# %3T%#Pl_250_12369084_240_5789784_NONE#3 ./%#Pl_231_16777215_240_5789784_bold#ghi %#Pl_240_5789784_236_3158064_NONE# %T%#Pl_231_16777215_236_3158064_NONE#                                         %#Pl_252_13684944_236_3158064_NONE# %#Pl_235_2500134_252_13684944_bold# Tabs '
 	call writefile(['Unexpected tabline', result], 'message.fail')
 	cquit
 endif
@@ -30,7 +30,7 @@ catch
 	cquit
 endtry
 
-if result isnot# '%T%#Pl_247_10395294_236_3158064_NONE# 1 ./abc  2 ./def %#Pl_236_3158064_240_5789784_NONE# %#Pl_250_12369084_240_5789784_NONE#3 ./%#Pl_231_16777215_240_5789784_bold#ghi %#Pl_240_5789784_236_3158064_NONE# %#Pl_231_16777215_236_3158064_NONE#                                         %#Pl_252_13684944_236_3158064_NONE# %#Pl_235_2500134_252_13684944_bold# Bufs '
+if result isnot# '%T%#Pl_247_10395294_236_3158064_NONE# 1 ./abc %#Pl_244_8421504_236_3158064_NONE# %#Pl_247_10395294_236_3158064_NONE#2 ./def %#Pl_236_3158064_240_5789784_NONE# %#Pl_250_12369084_240_5789784_NONE#3 ./%#Pl_231_16777215_240_5789784_bold#ghi %#Pl_240_5789784_236_3158064_NONE# %#Pl_231_16777215_236_3158064_NONE#                                         %#Pl_252_13684944_236_3158064_NONE# %#Pl_235_2500134_252_13684944_bold# Bufs '
 	call writefile(['Unexpected tabline (2)', result], 'message.fail')
 	cquit
 endif
@@ -42,7 +42,7 @@ catch
 	call writefile(['Exception while evaluating &tabline (3)', v:exception], 'message.fail')
 endtry
 
-if result isnot# '%T%#Pl_247_10395294_236_3158064_NONE# 1 ./abc  2 ./def %#Pl_236_3158064_240_5789784_NONE# %#Pl_250_12369084_240_5789784_NONE#3 ./%#Pl_231_16777215_240_5789784_bold#ghi %#Pl_240_5789784_236_3158064_NONE# %#Pl_231_16777215_236_3158064_NONE#                                         %#Pl_252_13684944_236_3158064_NONE# %#Pl_235_2500134_252_13684944_bold# Bufs '
+if result isnot# '%T%#Pl_247_10395294_236_3158064_NONE# 1 ./abc %#Pl_244_8421504_236_3158064_NONE# %#Pl_247_10395294_236_3158064_NONE#2 ./def %#Pl_236_3158064_240_5789784_NONE# %#Pl_250_12369084_240_5789784_NONE#3 ./%#Pl_231_16777215_240_5789784_bold#ghi %#Pl_240_5789784_236_3158064_NONE# %#Pl_231_16777215_236_3158064_NONE#                                         %#Pl_252_13684944_236_3158064_NONE# %#Pl_235_2500134_252_13684944_bold# Bufs '
 	call writefile(['Unexpected tabline (3)', result], 'message.fail')
 	cquit
 endif

--- a/tests/vim.py
+++ b/tests/vim.py
@@ -265,6 +265,14 @@ def eval(expr):
 		import os
 		assert os.path.basename(current.buffer.name).startswith('NERD_tree_')
 		return '/usr/include'
+	elif expr.startswith('getbufvar('):
+		import re
+		match = re.match(r'^getbufvar\((\d+), ["\'](.+)["\']\)$', expr)
+		if not match:
+			raise NotImplementedError(expr)
+		bufnr = int(match.group(1))
+		varname = match.group(2)
+		return _emul_getbufvar(bufnr, varname)
 	elif expr == 'tabpagenr()':
 		return current.tabpage.number
 	elif expr == 'tabpagenr("$")':


### PR DESCRIPTION
This pull request dramatically improves the experience of using the tabline with `showtabline=2` set. #1281 discusses an issue with Powerline flickering that is only caused when the bufferline is always displayed (with only one tab).

This is due to the prior usage of `vim_getbufoption(segment, 'buflisted')` in the conditionals of the bufferlister segment. Querying the buffer options through the vim python module's `option` attribute caused vim to think it needed to update the tabline for every keystroke after any event that changed the buffer's options.

Using the vim module's `eval` method to directly use the `buflisted(nr)` vim method instead does not cause vim to update the tabline after every keystroke, but rather after events that would change that status, thus fixing the flickering problem.

In addition to improving the flickering, I have also added additional highlight groups to further customize the colors used by the tabline when buffers are listed. You can now customize the colors based on a buffer's modified status, and the tabline has its own background and divider highlight group by default.