### PR TITLE
[Players - mpd] Use Unicode where available

### DIFF
--- a/powerline/segments/common/players.py
+++ b/powerline/segments/common/players.py
@@ -189,7 +189,11 @@ class MpdPlayerSegment(PlayerSegment):
 				'total': now_playing[3],
 			}
 		else:
-			client = mpd.MPDClient()
+			try:
+				client = mpd.MPDClient(use_unicode=True)
+			except TypeError:
+				# python-mpd 1.x does not support use_unicode
+				client = mpd.MPDClient()
 			client.connect(host, port)
 			if password:
 				client.password(password)


### PR DESCRIPTION
Otherwise the mpd function will fail when it encounters non-ASCII metadata as it tries to do a unicode.format() and attempts to decode the incoming data as ASCII, throwing a UnicodeDecodeError exception.

Fixes #1500 

Note that `python-mpd` (as opposed to `python-mpd2`) does not support `client.currentsong()`, so I don't think that actually works anymore.  Otherwise I'd be happy to a `try / except TypeError` + redo without the `use_unicode` parameter.  `python-mpd2` is happy with the extra argument under Python 3 (it's just mostly a no-op).