### PR TITLE
Add support for OS X en0 on internal_ip

### DIFF
--- a/powerline/segments/common/net.py
+++ b/powerline/segments/common/net.py
@@ -74,7 +74,7 @@ else:
 	_interface_starts = {
 		'eth':      10,  # Regular ethernet adapters         : eth1
 		'enp':      10,  # Regular ethernet adapters, Gentoo : enp2s0
-        'en':       10,  # OS X                              : en0 
+		'en':       10,  # OS X                              : en0 
 		'ath':       9,  # Atheros WiFi adapters             : ath0
 		'wlan':      9,  # Other WiFi adapters               : wlan1
 		'wlp':       9,  # Other WiFi adapters, Gentoo       : wlp5s0

--- a/powerline/segments/common/net.py
+++ b/powerline/segments/common/net.py
@@ -74,6 +74,7 @@ else:
 	_interface_starts = {
 		'eth':      10,  # Regular ethernet adapters         : eth1
 		'enp':      10,  # Regular ethernet adapters, Gentoo : enp2s0
+        'en':       10,  # OS X                              : en0 
 		'ath':       9,  # Atheros WiFi adapters             : ath0
 		'wlan':      9,  # Other WiFi adapters               : wlan1
 		'wlp':       9,  # Other WiFi adapters, Gentoo       : wlp5s0


### PR DESCRIPTION
This simple change ensures support for OS X interfaces on the common.net.internal_ip segment.