### PR TITLE
Remove status-utf8 option

### DIFF
--- a/powerline/bindings/tmux/powerline-base.conf
+++ b/powerline/bindings/tmux/powerline-base.conf
@@ -1,5 +1,4 @@
 set -g status on
-set -g status-utf8 on
 set -g status-interval 2
 set -g status-left-length 20
 set -g status-right '#(env "$POWERLINE_COMMAND" $POWERLINE_COMMAND_ARGS tmux right -R pane_id=\"`tmux display -p "#D"`\")'


### PR DESCRIPTION
It is incorrect to set it at all because what powerline outputs depends on 
locale used, and if locale is utf8 then tmux should already set this option.