### PR TITLE
Disable ExternalIpSegment on network exceptions

### DIFF
--- a/powerline/segments/common/net.py
+++ b/powerline/segments/common/net.py
@@ -30,7 +30,10 @@ def hostname(pl, segment_info, only_if_ssh=False, exclude_domain=False):
 
 
 def _external_ip(query_url='http://ipv4.icanhazip.com/'):
-	return urllib_read(query_url).strip()
+	try:
+		return urllib_read(query_url).strip()
+	except:
+		return ""
 
 
 class ExternalIpSegment(ThreadedSegment):
@@ -50,7 +53,8 @@ class ExternalIpSegment(ThreadedSegment):
 
 
 external_ip = with_docstring(ExternalIpSegment(),
-'''Return external IP address.
+'''Return external IP address. If an exception occurs during IP address
+retrieval, return empty string.
 
 :param str query_url:
 	URI to query for IP address, should return only the IP address as a text string


### PR DESCRIPTION
If  external  network  is  unavailable, ExternalIpSegment  will  fail  with  an
exception and  cause powerline to display  error text instead of  all segments.
This commit fixes  it by catching all exceptions  inside _external_ip function,
returning an empty  string in case of  an error which causes  Powerline to hide
ExternalIpSegment.

This pull request is referenced in issue #1512.