### PR TITLE
docs: Fix a small typo in develop/segments.rst

### DIFF
--- a/docs/source/develop/segments.rst
+++ b/docs/source/develop/segments.rst
@@ -305,7 +305,7 @@ Segment dictionary contains the following keys:
   ``side``
     Segment side: ``right`` or ``left``.
 
-  ``display_condition```
+  ``display_condition``
     Contains function that takes three position parameters: 
     :py:class:`powerline.PowerlineLogger` instance, :ref:`segment_info 
     <dev-segments-info>` dictionary and current mode and returns either ``True`` 


### PR DESCRIPTION
* The display_condition key in the docs was rendered as
  'display_condition`' due to a small typo. This commit fixes that.

Signed-off-by: mr.Shu <mr@shu.io>

-----------------

Note that this problem can be seen at https://powerline.readthedocs.org/en/latest/develop/segments.html#dev-segments-seg-contents where I noticed it too.