### PR TITLE
fix: Make dbus battery status consistent

### DIFF
--- a/powerline/segments/common/bat.py
+++ b/powerline/segments/common/bat.py
@@ -57,7 +57,7 @@ def _fetch_battery_info(pl):
 						dbus.Interface(dev, dbus_interface=devinterface).Get(
 							devtype_name,
 							'State'
-						) == 1
+						) != 2
 					)
 				pl.debug('Not using DBUS+UPower as no batteries were found')
 


### PR DESCRIPTION
* In #1499 a change was introduced that made use of the "Discharging"
  status of a battery in order to detect whether the AC power is
  available.

  The DBus part of the function that gets this data, however, stayed
  unchanged. In order to keep it consistent this commit changes it in
  such a way that it preforms the same function as the code introduced
  in #1499 by checking for the Discharging state of the battery as
  described here:
  http://upower.freedesktop.org/docs/Device.html#Device:State

Signed-off-by: mr.Shu <mr@shu.io>