### PR TITLE
Fix bug in xrandr output detection

### DIFF
--- a/powerline/bindings/wm/__init__.py
+++ b/powerline/bindings/wm/__init__.py
@@ -24,14 +24,14 @@ def get_i3_connection():
 	return conn
 
 
-XRANDR_OUTPUT_RE = re.compile(r'^(?P<name>[0-9A-Za-z-]+) connected (?P<width>\d+)x(?P<height>\d+)\+(?P<x>\d+)\+(?P<y>\d+)', re.MULTILINE)
+XRANDR_OUTPUT_RE = re.compile(r'^(?P<name>[0-9A-Za-z-]+) connected(?P<primary> primary)? (?P<width>\d+)x(?P<height>\d+)\+(?P<x>\d+)\+(?P<y>\d+)', re.MULTILINE)
 
 
 def get_connected_xrandr_outputs(pl):
 	'''Iterate over xrandr outputs
 
 	Outputs are represented by a dictionary with ``name``, ``width``, 
-	``height``, ``x`` and ``y`` keys.
+	``height``, ``primary``, ``x`` and ``y`` keys.
 	'''
 	return (match.groupdict() for match in XRANDR_OUTPUT_RE.finditer(
 	    run_cmd(pl, ['xrandr', '-q'])


### PR DESCRIPTION
When there is a primary output set the current regex doesn't match that line / output.