### PR TITLE
Update command used to install macvim with brew

### DIFF
--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -56,7 +56,7 @@ Vim installation
 Any terminal vim version with Python 3.2+ or Python 2.6+ support should work, 
 but MacVim users need to install it using the following command::
 
-    brew install macvim --env-std --override-system-vim
+    brew install macvim --env-std --with-override-system-vim
 
 Fonts installation
 ==================


### PR DESCRIPTION
Flag `--override-system-vim` is deprecated.

Fixes #1526.