### PR TITLE
More specific instructions for iPython

### DIFF
--- a/docs/source/usage/other.rst
+++ b/docs/source/usage/other.rst
@@ -114,11 +114,12 @@ For IPython<0.11 add the following lines to :file:`.ipython/ipy_user_conf.py`:
     # create skeleton ipy_user_conf.py file):
     powerline_setup()
 
-For IPython>=0.11 add the following line to :file:`ipython_config.py` file in 
-the used profile:
+For IPython>=0.11 add the following line to
+:file:`~/.ipython/profile_default/ipython_config.py` file in the used profile:
 
 .. code-block:: Python
 
+    c = get_config()
     c.InteractiveShellApp.extensions = [
         'powerline.bindings.ipython.post_0_11'
     ]


### PR DESCRIPTION
This PR is improving documentation about how to integrate Powerline with iPython. Tested on Arch Linux and Ubuntu.