### PR TITLE
Increase socket backlog number for `powerline-daemon`

### DIFF
--- a/scripts/powerline-daemon
+++ b/scripts/powerline-daemon
@@ -231,7 +231,7 @@ def do_one(sock, read_sockets, write_sockets, result_map):
 
 
 def main_loop(sock):
-	sock.listen(1)
+	sock.listen(128)
 	sock.setblocking(0)
 
 	read_sockets, write_sockets = set(), set()


### PR DESCRIPTION
The number `1` for backlog is quite small.

On my FreeBSD box, I got this message:
```
Mar 28 19:01:43 imfsa kernel: sonewconn: pcb 0xfffff802088b25a0: Listen queue overflow: 2 already in queue awaiting acceptance (32 occurrences)
```
and
```
% netstat -na | grep fffff802088b25a0
ffffff802088b25a0 stream      0      0 fffff802088b25a0        0        0        0 /tmp/powerline-ipc-1001
```

Increasing the backlog number can solve the queue overflow problem.