### PR TITLE
Fix trailing whitespace segment on Python 3.

### DIFF
--- a/powerline/segments/vim/__init__.py
+++ b/powerline/segments/vim/__init__.py
@@ -578,7 +578,7 @@ def trailing_whitespace(pl, segment_info):
 	else:
 		buf = segment_info['buffer']
 		bws = b' \t'
-		sws = str(bws)
+		sws = str(' \t')  # Ignore unicode_literals and use native str.
 		for i in range(len(buf)):
 			try:
 				line = buf[i]


### PR DESCRIPTION
Using str() on a bytestring produces the repr on Python 3, not some
implicitly decoded string. So use an explicit decode instead.

Fixes #1613.