### PR TITLE
reset last status code before calling zle reset-prompt

### DIFF
--- a/powerline/bindings/zsh/powerline.zsh
+++ b/powerline/bindings/zsh/powerline.zsh
@@ -74,7 +74,9 @@ _powerline_init_modes_support() {
 	}
 
 	function -g _powerline_zle_keymap_select() {
+		local last_status=$?
 		_powerline_set_true_keymap_name $KEYMAP
+		$(exit last_status)
 		zle reset-prompt
 		test -z "$_POWERLINE_SAVE_WIDGET" || zle $_POWERLINE_SAVE_WIDGET
 	}


### PR DESCRIPTION
Currently, toggling modes in the Zsh line editor causes the `powerline.segments.shell.last_status` segment to be incorrectly cleared, because the return code of `_powerline_set_true_keymap_name $KEYMAP` fills the value of `$?` at draw time. This patch to `bindings/zsh/powerline.zsh` captures the last status code and restores it before redrawing the prompt.
