### PR TITLE
Python process replication fix while restarting Awesome 

### DIFF
--- a/powerline/bindings/awesome/powerline.lua
+++ b/powerline/bindings/awesome/powerline.lua
@@ -8,4 +8,4 @@ function powerline(mode, widget) end
 
 bindings_path = string.gsub(debug.getinfo(1).source:match('@(.*)$'), '/[^/]+$', '')
 powerline_cmd = bindings_path .. '/powerline-awesome.py'
-awful.util.spawn_with_shell('ps -C powerline-awesome.py || ' .. powerline_cmd)
+awful.util.spawn_with_shell('ps aux | grep -e powerline-awesome.py | grep -v grep || ' .. powerline_cmd)


### PR DESCRIPTION
Hello,

I run into an issue with **powerline-awesome.py** replication while restarting **Awesome Window Manager**. After some investigation I've found that `ps -C powerline-awesome.py` is not returning proper results. At least in my version of `ps` (I'm using **Arch**):

> ps --version 
> ps from procps-ng 3.3.12

So I modified the `powerline/bindings/awesome/powerline.lua` a bit to use `ps aux` and `grep`  (which should work similarly on all Linux distributions - correct me if I'm wrong).

Finally I created this pull request to share my experience - feel free to reject it if it's useless :)

Lukasz

PS Keep up the good work! Powerline is really awesome!

