### PR TITLE
retry 5 times before throwing an exception

### DIFF
--- a/powerline/segments/common/wthr.py
+++ b/powerline/segments/common/wthr.py
@@ -136,13 +136,20 @@ class WeatherSegment(KwThreadedSegment):
 			return url
 
 	def compute_state(self, location_query):
-		url = self.get_request_url(location_query)
-		raw_response = urllib_read(url)
-		if not raw_response:
-			self.error('Failed to get response')
-			return None
+		for i in range(5):
+			try:
+				url = self.get_request_url(location_query)
+				raw_response = urllib_read(url)
+				if not raw_response:
+					self.error('Failed to get response')
+					return None
 
-		response = json.loads(raw_response)
+				response = json.loads(raw_response)
+				if response['query']['results'] is not None:
+					break
+			except (KeyError, ValueError):
+				self.exception('Yahoo returned malformed or unexpected response: {0}', repr(raw_response))
+				return None
 		try:
 			condition = response['query']['results']['channel']['item']['condition']
 			condition_code = int(condition['code'])


### PR DESCRIPTION
after upgrading my system to latest I had some issue with the weather segment.  I was getting sporadic errors:
```ERROR:tmux:WeatherSegment:Exception while computing state for None: 'NoneType' object has no attribute ' getitem '```
this happens because some times `response['query']['results'] is None`  
so I added at least a retry up to 5 times.  
problem solved for me: this is related to: #1119