### PR TITLE
Make length of `output_padding` in renderer controllable

### DIFF
--- a/docs/source/configuration/reference.rst
+++ b/docs/source/configuration/reference.rst
@@ -361,6 +361,10 @@ ascii                       Theme without any unicode characters at all
        is set in the local themes it will be ignored. This option may also be 
        ignored in some bindings.
 
+``outer_padding``
+    Defines number of spaces at the end of output (on the right side) or at 
+    the start of output (on the left side). Defaults to ``1``.
+
 
 ``dividers``
     Defines the dividers used in all Powerline extensions.

--- a/powerline/renderer.py
+++ b/powerline/renderer.py
@@ -458,7 +458,7 @@ class Renderer(object):
 					segment is first_segment
 					if side == 'left' else
 					segment is last_segment
-				))
+				)) * theme.outer_padding
 
 				draw_divider = segment['draw_' + divider_type + '_divider']
 				segment_len += outer_padding
@@ -519,7 +519,7 @@ class Renderer(object):
 					segment is first_segment
 					if side == 'left' else
 					segment is last_segment
-				)) * ' '
+				)) * theme.outer_padding * ' '
 				divider_type = 'soft' if compare_segment['highlight']['bg'] == segment['highlight']['bg'] else 'hard'
 
 				divider_highlighted = ''

--- a/powerline/theme.py
+++ b/powerline/theme.py
@@ -69,6 +69,7 @@ class Theme(object):
 			self.cursor_space_multiplier = None
 		self.cursor_columns = theme_config.get('cursor_columns')
 		self.spaces = theme_config['spaces']
+		self.outer_padding = int(theme_config.get('outer_padding', 1))
 		self.segments = []
 		self.EMPTY_SEGMENT = {
 			'contents': None,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -550,6 +550,28 @@ class TestDisplayCondition(TestRender):
 			self.assertRenderEqual(p, '{56} s1{6-}>>{--}', mode='m1')
 
 
+class TestOuterPadding(TestRender):
+	@add_args
+	def test_outer_padding_left(self, p, config):
+		config['themes/' + UT]['outer_padding'] = 5
+		self.assertRenderEqual(p, '{121}     s{24}>>{344}g{4-}>>{--}', side='left')
+
+	@add_args
+	def test_outer_padding_right(self, p, config):
+		config['themes/' + UT]['outer_padding'] = 5
+		self.assertRenderEqual(p, '{4-}<<{344}f     {--}', side='right')
+
+	@add_args
+	def test_outer_padding_ten(self, p, config):
+		config['themes/' + UT]['outer_padding'] = 10
+		self.assertRenderEqual(p, '{121}          s  {24}>>{344}g{34}>{34}|{344} f          {--}', width=30)
+
+	@add_args
+	def test_outer_padding_zero(self, p, config):
+		config['themes/' + UT]['outer_padding'] = 0
+		self.assertRenderEqual(p, '{121}s            {24}>>{344}g{34}>{34}|{344}           f{--}', width=30)
+
+
 class TestSegmentAttributes(TestRender):
 	@add_args
 	def test_no_attributes(self, p, config):


### PR DESCRIPTION
Defaults to previous behaviour (length 1).

I'm not sure if anyone else would be interested in this change, but the compulsory padding was bugging me so here it is.