### PR TITLE
Assume latest tmux version if -V returns 'master'

### DIFF
--- a/powerline/bindings/tmux/__init__.py
+++ b/powerline/bindings/tmux/__init__.py
@@ -76,6 +76,8 @@ def get_tmux_version(pl):
 	version_string = get_tmux_output(pl, '-V')
 	_, version_string = version_string.split(' ')
 	version_string = version_string.strip()
+	if version_string == 'master':
+		return TmuxVersionInfo(float('inf'), 0, version_string)
 	major, minor = version_string.split('.')
 	suffix = DIGITS.subn('', minor)[0] or None
 	minor = NON_DIGITS.subn('', minor)[0]


### PR DESCRIPTION
See #1727.

It seems that [tmux/tmux](https://github.com/tmux/tmux/branches) is only developed on a single `master` branch, so having that comparison hardcoded is probably appropriate, but hardcoding the latest tmux version to be bumped every release seems less-than-ideal to me, open to suggestions on that.

Since tmux releases may prompt changes to the tmux bindings anyhow though, it  may be 'good enough' but I suspect something better should be done in `powerline/bindings/config.py` to snap to the latest version based on the available tmux.conf's in the binding directory.