### PR TITLE
Fix i3 bar bindings

### DIFF
--- a/docs/source/usage/wm-widgets.rst
+++ b/docs/source/usage/wm-widgets.rst
@@ -82,20 +82,11 @@ All ``powerline-lemonbar.py`` arguments:
 I3 bar
 ======
 
-.. note::
-   As the patch to include background-colors in i3bar is likely not to be 
-   merged, it is recommended to instead run ``bar`` (see above). The source for 
-   i3bgbar is however still available `here 
-   <https://github.com/S0lll0s/i3bgbar>`_.
-
-Add the following to :file:`~/.i3/config`::
+Add the following to :file:`~/.config/i3/config`::
 
     bar {
-        i3bar_command i3bgbar
-
         status_command python /path/to/powerline/bindings/i3/powerline-i3.py
         font pango:PowerlineFont 12
     }
 
-where ``i3bgbar`` may be replaced with the path to the custom i3bar binary and 
-``PowerlineFont`` is any system font with powerline support.
+where ``PowerlineFont`` is any system font with powerline support.

--- a/powerline/bindings/i3/powerline-i3.py
+++ b/powerline/bindings/i3/powerline-i3.py
@@ -13,28 +13,34 @@ from powerline import Powerline
 from powerline.lib.monotonic import monotonic
 
 
+class I3Powerline(Powerline):
+	'''Powerline child for i3bar
+
+	Currently only changes the default log target.
+	'''
+	default_log_stream = sys.stderr
+
+
 if __name__ == '__main__':
 	name = 'wm'
 	if len(sys.argv) > 1:
 		name = sys.argv[1]
 
-	powerline = Powerline(name, renderer_module='i3bar')
+	powerline = I3Powerline(name, renderer_module='i3bar')
 	powerline.update_renderer()
 
 	interval = 0.5
 
-	print ('{"version": 1, "custom_workspace": true}')
+	print ('{"version": 1}')
 	print ('[')
-	print ('\t[[],[]]')
+	print ('[]')
 
 	lock = Lock()
 
 	def render(event=None, data=None, sub=None):
 		global lock
 		with lock:
-			s = '[\n' + powerline.render(side='right')[:-2] + '\n]\n'
-			s += ',[\n' + powerline.render(side='left')[:-2] + '\n]'
-			print (',[\n' + s + '\n]')
+			print (',[' + powerline.render()[:-1] + ']')
 			sys.stdout.flush()
 
 	sub = i3.Subscription(render, 'workspace')

--- a/powerline/renderers/i3bar.py
+++ b/powerline/renderers/i3bar.py
@@ -29,9 +29,8 @@ class I3barRenderer(Renderer):
 				segment['color'] = '#{0:06x}'.format(fg[1])
 		if bg is not None:
 			if bg is not False and bg[1] is not False:
-				segment['background_color'] = '#{0:06x}'.format(bg[1])
-		# i3bar “pseudo json” requires one line at a time
-		return json.dumps(segment) + ',\n'
+				segment['background'] = '#{0:06x}'.format(bg[1])
+		return json.dumps(segment) + ','
 
 
 renderer = I3barRenderer


### PR DESCRIPTION
Specifically:

- Do not log exceptions to the same location data is output.
- Fix format, i3bar is no longer using “pseudo-JSON”, also not sure whether it 
  ever used format `[[right list], [left list]]`, but it definitely does not 
  now.
- i3bgbar branch is no longer available.
- Yet i3wm supports background color, just with the different key (`background` 
  vs `background_color`).