### PR TITLE
fontconfig: add Terminus font

### DIFF
--- a/font/10-powerline-symbols.conf
+++ b/font/10-powerline-symbols.conf
@@ -102,4 +102,8 @@
 		<family>Meslo LG S DZ</family>
 		<prefer><family>PowerlineSymbols</family></prefer>
 	</alias>
+	<alias>
+		<family>Terminus</family>
+		<prefer><family>PowerlineSymbols</family></prefer>
+	</alias>
 </fontconfig>


### PR DESCRIPTION
Add Terminus to the fontconfig file. Tested to work fine on Ubuntu 16.04.