### PR TITLE
change spotify to use applescript on OS X

### DIFF
--- a/powerline/segments/common/players.py
+++ b/powerline/segments/common/players.py
@@ -380,7 +380,7 @@ Requires ``osascript`` available in $PATH.
 ''').format(_common_args.format('spotify_apple_script')))
 
 
-if 'dbus' in globals() or not sys.platform.startswith('darwin'):
+if not sys.platform.startswith('darwin'):
 	spotify = spotify_dbus
 	_old_name = 'spotify_dbus'
 else:


### PR DESCRIPTION
changed choosing logic. because:
spotify on OS X does not support dbus message so applescript had to be used.
other system does not support applescript so dbus has to be used.