### PR TITLE
Fix handling of empty config.json

### DIFF
--- a/powerline/lib/config.py
+++ b/powerline/lib/config.py
@@ -18,7 +18,12 @@ def open_file(path):
 
 def load_json_config(config_file_path, load=json.load, open_file=open_file):
 	with open_file(config_file_path) as config_file_fp:
-		return load(config_file_fp)
+		try:
+			return load(config_file_fp)
+		except json.JSONDecodeError as err:
+			# Handle empty config file gracefully
+			if str(err) != "Expecting value: line 1 column 1 (char 0)":
+				raise
 
 
 class DummyWatcher(object):

--- a/powerline/lib/dict.py
+++ b/powerline/lib/dict.py
@@ -36,6 +36,10 @@ def mergedicts(d1, d2, remove=True):
 	First dictionary is modified in-place.
 	'''
 	_setmerged(d1, d2)
+
+	if d2 == None:
+		return
+
 	for k in d2:
 		if k in d1 and isinstance(d1[k], dict) and isinstance(d2[k], dict):
 			mergedicts(d1[k], d2[k], remove)
@@ -72,6 +76,10 @@ def mergedicts_copy(d1, d2):
 	'''
 	ret = d1.copy()
 	_setmerged(ret, d2)
+
+	if d2 == None:
+		return ret
+
 	for k in d2:
 		if k in d1 and isinstance(d1[k], dict) and isinstance(d2[k], dict):
 			ret[k] = mergedicts_copy(d1[k], d2[k])


### PR DESCRIPTION
When `~/.config/powerline/config.json` and friends are empty, `powerline-lint` will fail with:

```
Traceback (most recent call last):
  File "/usr/bin/powerline-lint", line 13, in <module>
    sys.exit(check(args.config_path, args.debug))
  File "/usr/lib/python3.6/site-packages/powerline/lint/__init__.py", line 496, in check
    main_config = load_config('config', find_config_files, config_loader)
  File "/usr/lib/python3.6/site-packages/powerline/__init__.py", line 199, in load_config
    mergedicts(ret, config_loader.load(path))
  File "/usr/lib/python3.6/site-packages/powerline/lib/dict.py", line 39, in mergedicts
    for k in d2:
TypeError: 'NoneType' object is not iterable
```

and opening a new shell using powerline gives:

```
Traceback (most recent call last):
  File "/usr/bin/powerline-config", line 20, in <module>
    pl = config.create_powerline_logger(args)
  File "/usr/lib/python3.6/site-packages/powerline/bindings/config.py", line 222, in create_powerline_logger
    config = get_main_config(args)
  File "/usr/lib/python3.6/site-packages/powerline/bindings/config.py", line 218, in get_main_config
    return load_config('config', find_config_files, config_loader)
  File "/usr/lib/python3.6/site-packages/powerline/__init__.py", line 199, in load_config
    mergedicts(ret, config_loader.load(path))
  File "/usr/lib/python3.6/site-packages/powerline/lib/config.py", line 160, in load
    r = self._load(path)
  File "/usr/lib/python3.6/site-packages/powerline/lib/config.py", line 21, in load_json_config
    return load(config_file_fp)
  File "/usr/lib64/python3.6/json/__init__.py", line 299, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  File "/usr/bin/powerline-config", line 20, in <module>
    pl = config.create_powerline_logger(args)
  File "/usr/lib/python3.6/site-packages/powerline/bindings/config.py", line 222, in create_powerline_logger
    config = get_main_config(args)
  File "/usr/lib/python3.6/site-packages/powerline/bindings/config.py", line 218, in get_main_config
    return load_config('config', find_config_files, config_loader)
  File "/usr/lib/python3.6/site-packages/powerline/__init__.py", line 199, in load_config
    mergedicts(ret, config_loader.load(path))
  File "/usr/lib/python3.6/site-packages/powerline/lib/config.py", line 160, in load
    r = self._load(path)
  File "/usr/lib/python3.6/site-packages/powerline/lib/config.py", line 21, in load_json_config
    return load(config_file_fp)
  File "/usr/lib64/python3.6/json/__init__.py", line 299, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This fixes the merging of None dicts and catches the JSONDecodeError.