### PR TITLE
Fixes typo in documentation

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -8,7 +8,7 @@ Application-specific requirements
 Vim plugin requirements
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The vim plugin requires a vim version with Python support compiled in. Presense 
+The vim plugin requires a vim version with Python support compiled in. Presence 
 of Python support in Vim can be checked by running ``vim --version | grep 
 +python``.
 


### PR DESCRIPTION
In the first paragraphof usage.html: "s/Presense/Presence of Python support in vim..."