### PR TITLE
Corrected interface lookups to work with systemd

### DIFF
--- a/powerline/segments/common/net.py
+++ b/powerline/segments/common/net.py
@@ -85,21 +85,16 @@ else:
 		'vboxnet':  -5,  # VirtualBox bridge interface       : vboxnet0
 	}
 
-	_interface_start_re = re.compile(r'^([a-z]+?)(\d|$)')
-
 	def _interface_key(interface):
-		match = _interface_start_re.match(interface)
-		if match:
-			try:
-				base = _interface_starts[match.group(1)] * 100
-			except KeyError:
-				base = 500
-			if match.group(2):
-				return base - int(match.group(2))
-			else:
-				return base
-		else:
-			return 0
+		for prefix,score in _interface_starts.items():
+			if(interface.startswith(prefix)):
+				try:
+					# This prevents a huge negative when the interface name is a mac address
+					modifier = int(re.sub('[^0-9]+', '', interface)) < 10 or 0
+				except:
+					modifier = 0
+				return score * 100 - modifier
+		return 0
 
 	def internal_ip(pl, interface='auto', ipv=4):
 		family = netifaces.AF_INET6 if ipv == 6 else netifaces.AF_INET


### PR DESCRIPTION
This should allow lookups to be performed against the new systemd interface (as well as all other interfaces) simply by comparing the prefix of the interface name rather than the first characters only. This also allows for enx interfaces that use the mac address as the identifier and throws the modifier for a spin by returning a crazy long integer.

Reference: https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c#L20