### PR TITLE
Tmux truecolor support

### DIFF
--- a/powerline/renderers/tmux.py
+++ b/powerline/renderers/tmux.py
@@ -53,7 +53,7 @@ class TmuxRenderer(Renderer):
 			else:
 				if term_truecolor:
 					hex_code = "{0:06x}".format(fg[1])
-					tmux_attrs += ['fg=#' + hex_code]
+					tmux_attrs += ['fg=' + hex_code]
 				else:
 					tmux_attrs += ['fg=colour' + str(fg[0])]
 		if bg is not None:
@@ -62,7 +62,7 @@ class TmuxRenderer(Renderer):
 			else:
 				if term_truecolor:
 					hex_code = "{0:06x}".format(bg[1])
-					tmux_attrs += ['bg=#' + hex_code]
+					tmux_attrs += ['bg=' + hex_code]
 				else:
 					tmux_attrs += ['bg=colour' + str(bg[0])]
 		if attrs is not None:

--- a/powerline/renderers/tmux.py
+++ b/powerline/renderers/tmux.py
@@ -44,16 +44,27 @@ class TmuxRenderer(Renderer):
 		if not attrs and not bg and not fg:
 			return ''
 		tmux_attrs = []
+		# Is truecolor supported?
+		is_fbterm = self.used_term_escape_style == 'fbterm'
+		term_truecolor = not is_fbterm and self.term_truecolor
 		if fg is not None:
 			if fg is False or fg[0] is False:
 				tmux_attrs += ['fg=default']
 			else:
-				tmux_attrs += ['fg=colour' + str(fg[0])]
+				if term_truecolor:
+					hex_code = "{0:06x}".format(fg[1])
+					tmux_attrs += ['fg=#' + hex_code]
+				else:
+					tmux_attrs += ['fg=colour' + str(fg[0])]
 		if bg is not None:
 			if bg is False or bg[0] is False:
 				tmux_attrs += ['bg=default']
 			else:
-				tmux_attrs += ['bg=colour' + str(bg[0])]
+				if term_truecolor:
+					hex_code = "{0:06x}".format(bg[1])
+					tmux_attrs += ['bg=#' + hex_code]
+				else:
+					tmux_attrs += ['bg=colour' + str(bg[0])]
 		if attrs is not None:
 			tmux_attrs += attrs_to_tmux_attrs(attrs)
 		return '#[' + ','.join(tmux_attrs) + ']'


### PR DESCRIPTION
Fixes issue #1863.

This PR adds some code to `powerline/renderers/tmux.py` that checks if truecolor is enabled, and if so, uses the truecolor 24-bit hex colour rather than a 256-colour version.