### PR TITLE
(fix) updated linux spotify app dbus config

### DIFF
--- a/powerline/segments/common/players.py
+++ b/powerline/segments/common/players.py
@@ -311,10 +311,10 @@ class SpotifyDbusPlayerSegment(PlayerSegment):
 		return _get_dbus_player_status(
 			pl=pl,
 			player_name='Spotify',
-			bus_name='com.spotify.qt',
-			player_path='/',
+			bus_name='org.mpris.MediaPlayer2.spotify',
+			player_path='/org/mpris/MediaPlayer2',
 			iface_prop='org.freedesktop.DBus.Properties',
-			iface_player='org.freedesktop.MediaPlayer2',
+			iface_player='org.mpris.MediaPlayer2.Player',
 		)
 
 


### PR DESCRIPTION
Updating linux dbus config according to Spotify client version: 1.0.69.336.g7edcc575.

Now player segment works as expected.