### PR TITLE
Fix for i3 if you have i3-py and i3ipc install

### DIFF
--- a/powerline/bindings/wm/__init__.py
+++ b/powerline/bindings/wm/__init__.py
@@ -25,12 +25,13 @@ def i3_subscribe(conn, event, callback):
 		Function to run on event.
 	'''
 	try:
-		import i3
+		import i3ipc
 	except ImportError:
-		pass
-	else:
+		import i3
 		conn.Subscription(callback, event)
 		return
+	else:
+		pass
 
 	conn.on(event, callback)
 


### PR DESCRIPTION
This should fix Json error with i3bar binding #1875.

I reproduce the bug by having i3-py and i3ipc at the same time. In get_i3_connection() we prioritize i3ipc which is good. But in i3_subscribe we prioritize i3-py which make a confilct.

I've tested with only i3-py, only i3ipcand with both.