### PR TITLE
Adjusted calculating the number of battery hearts

### DIFF
--- a/powerline/segments/common/bat.py
+++ b/powerline/segments/common/bat.py
@@ -270,7 +270,7 @@ def battery(pl, format='{ac_state} {capacity:3.0%}', steps=5, gamify=False, full
 	ret = []
 	if gamify:
 		denom = int(steps)
-		numer = int(denom * capacity / 100)
+		numer = int(round(denom * capacity / 100.0, 0))
 		ret.append({
 			'contents': online if ac_powered else offline,
 			'draw_inner_divider': False,


### PR DESCRIPTION
This PR changes the logic behind how the number of full/empty hearts are calculated. The previous implementation worked fine but produced (at least for me) illogical/unintuitive results.

For example, I’d expect to see 3/5 hearts on 51% battery whereas the previous implementation displayed only 2/5.
Similarly, 99% battery displayed 4/5 hearts before, but with this change, it stays on 5/5 until the battery drops below 89%.

Thank you for consideration!