### PR TITLE
Update docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -38,18 +38,6 @@ Generic requirements
     Until bazaar supports Python-3 or PyPy powerline will not support
     repository information when running in these interpreters.
 
-.. _repository-root:
-
-.. note::
-   When using ``pip``, the ``{repository_root}`` directory referenced in
-   documentation may be found using ``pip show powerline-status``. In the output
-   of ``pip show`` there is a line like ``Location: {path}``, that ``{path}`` is
-   ``{repository_root}``. Unless it is ``--editable`` installation this is only
-   applicable for ``{repository_root}/powerline/…`` paths: something like
-   ``{repository_root}/scripts/powerline-render`` is not present.
-
-   When using other packages referenced paths may not exist, in this case refer
-   to package documentation.
 
 Pip installation
 ================
@@ -96,6 +84,26 @@ instructions. If these do not apply to you, apply the following steps.
    - ``https``: ``git+https://github.com/powerline/powerline``
 
    The ``git`` protocol should be the fastest, but the least secure one.
+
+.. _repository-root:
+
+.. rubric:: Repository root
+
+Since you used ``pip`` to install powerline, you will need to know the
+``{repository_root}`` directory to set up powerline.
+
+To display the ``{repository_root}``:
+
+#. Run ``pip show powerline-status``.
+#. Find the output line containing ``Location: {path}``. That ``{path}``
+   is the ``{repository_root}``.
+
+Unless you used the ``--editable`` flag during the installation, this is
+only applicable for ``{repository_root}/powerline/…`` paths: something
+like ``{repository_root}/scripts/powerline-render`` is not present.
+
+When using other packages referenced paths may not exist, in this case refer
+to the package documentation.
 
 Fonts installation
 ==================

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -54,6 +54,9 @@ Generic requirements
 Pip installation
 ================
 
+Refer to :ref:`install-osx` or :ref:`install-linux` for platform-specific
+instructions. If these do not apply to you, apply the following steps.
+
 - To install the latest release, run:
 
   .. code-block:: sh

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,44 +5,44 @@ Installation
 Generic requirements
 ====================
 
-* Python 2.6 or later, 3.2 or later, PyPy 2.0 or later, PyPy3 2.3 or later. It
+* Python 2.6 or later, 3.2 or later, PyPy 2.0 or later, PyPy3 2.3 or later. It 
   is the only non-optional requirement.
 
   .. warning:
-     It is highly advised to use UCS-4 version of Python because UCS-2 version
-     uses significantly slower text processing (length determination and
-     non-printable character replacement) functions due to the need of
-     supporting unicode characters above U+FFFF which are represented as
-     surrogate pairs. This price will be paid even if configuration has no such
+     It is highly advised to use UCS-4 version of Python because UCS-2 version 
+     uses significantly slower text processing (length determination and 
+     non-printable character replacement) functions due to the need of 
+     supporting unicode characters above U+FFFF which are represented as 
+     surrogate pairs. This price will be paid even if configuration has no such 
      characters.
 
-* C compiler. Required to build powerline client on linux. If it is not present
+* C compiler. Required to build powerline client on linux. If it is not present 
   then powerline will fall back to shell script or python client.
-* ``socat`` program. Required for shell variant of client which runs a bit
+* ``socat`` program. Required for shell variant of client which runs a bit 
   faster than python version of the client, but still slower than C version.
-* ``psutil`` python package. Required for some segments like cpu_percent. Some
+* ``psutil`` python package. Required for some segments like cpu_percent. Some 
   segments have linux-only fallbacks for ``psutil`` functionality.
-* ``hglib`` python package *and* mercurial executable. Required to work with
+* ``hglib`` python package *and* mercurial executable. Required to work with 
   mercurial repositories.
-* ``pygit2`` python package or ``git`` executable. Required to work with ``git``
+* ``pygit2`` python package or ``git`` executable. Required to work with ``git`` 
   repositories.
-* ``bzr`` python package (note: *not* standalone executable). Required to work
+* ``bzr`` python package (note: *not* standalone executable). Required to work 
   with bazaar repositories.
-* ``pyuv`` python package. Required for :ref:`libuv-based watcher
+* ``pyuv`` python package. Required for :ref:`libuv-based watcher 
   <config-common-watcher>` to work.
-* ``i3ipc`` python package. Required for i3wm bindings and segments.
-* ``xrandr`` program. Required for the multi-monitor lemonbar binding and the
+* ``i3ipc`` python package. Required for i3wm bindings and segments. 
+* ``xrandr`` program. Required for the multi-monitor lemonbar binding and the 
   :py:func:`powerline.listers.i3wm.output_lister`.
 
 .. note::
-    Until bazaar supports Python-3 or PyPy powerline will not support
+    Until bazaar supports Python-3 or PyPy powerline will not support 
     repository information when running in these interpreters.
 
 
 Pip installation
 ================
 
-Refer to :ref:`install-osx` or :ref:`install-linux` for platform-specific
+Refer to :ref:`install-osx` or :ref:`install-linux` for platform-specific 
 instructions. If these do not apply to you, apply the following steps.
 
 - To install the latest release, run:
@@ -51,7 +51,7 @@ instructions. If these do not apply to you, apply the following steps.
 
      pip install powerline-status
 
-  .. note:: Due to a naming conflict with an unrelated project, Powerline
+  .. note:: Due to a naming conflict with an unrelated project, Powerline 
      is available on PyPi under the ``powerline-status`` name.
 
 - To install the current development version, run:
@@ -66,7 +66,7 @@ instructions. If these do not apply to you, apply the following steps.
 
      pip install --user --editable={path_to_powerline}
 
-  .. note:: In this case ``pip`` will not install ``powerline``
+  .. note:: In this case ``pip`` will not install ``powerline`` 
      executable. You might need to run:
 
      .. code-block:: sh
@@ -77,7 +77,7 @@ instructions. If these do not apply to you, apply the following steps.
      present in ``$PATH``).
 
 .. note::
-   If your ISP blocks the git protocol for some reason, use the following
+   If your ISP blocks the git protocol for some reason, use the following 
    Github protocols:
 
    - ``ssh``: ``git+ssh://git@github.com/powerline/powerline``
@@ -89,7 +89,7 @@ instructions. If these do not apply to you, apply the following steps.
 
 .. rubric:: Repository root
 
-Since you used ``pip`` to install powerline, you will need to know the
+Since you used ``pip`` to install powerline, you will need to know the 
 ``{repository_root}`` directory to set up powerline.
 
 To display the ``{repository_root}``:
@@ -98,28 +98,28 @@ To display the ``{repository_root}``:
 #. Find the output line containing ``Location: {path}``. That ``{path}``
    is the ``{repository_root}``.
 
-Unless you used the ``--editable`` flag during the installation, this is
-only applicable for ``{repository_root}/powerline/…`` paths: something
+Unless you used the ``--editable`` flag during the installation, this is 
+only applicable for ``{repository_root}/powerline/…`` paths: something 
 like ``{repository_root}/scripts/powerline-render`` is not present.
 
-When using other packages referenced paths may not exist, in this case refer
+When using other packages referenced paths may not exist, in this case refer 
 to the package documentation.
 
 Fonts installation
 ==================
 
-Powerline uses several special glyphs to get the arrow effect and some custom
-symbols for developers. This requires having either a symbol font or a patched
+Powerline uses several special glyphs to get the arrow effect and some custom 
+symbols for developers. This requires having either a symbol font or a patched 
 font installed in the system.
 
-The used application (e.g. terminal emulator) must
-also either be configured to use patched fonts (in some cases even support it
-because custom glyphs live in private use area which some applications reserve
-for themselves) or support fontconfig for powerline to work properly with
+The used application (e.g. terminal emulator) must 
+also either be configured to use patched fonts (in some cases even support it 
+because custom glyphs live in private use area which some applications reserve 
+for themselves) or support fontconfig for powerline to work properly with 
 powerline-specific glyphs.
 
-:ref:`24-bit color support <config-common-term_truecolor>` may be enabled if
-used terminal emulator supports it (see :ref:`the terminal emulator support
+:ref:`24-bit color support <config-common-term_truecolor>` may be enabled if 
+used terminal emulator supports it (see :ref:`the terminal emulator support 
 matrix <usage-terminal-emulators>`).
 
 There are 2 ways to get powerline glyphs displayed:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,33 +5,33 @@ Installation
 Generic requirements
 ====================
 
-* Python 2.6 or later, 3.2 or later, PyPy 2.0 or later, PyPy3 2.3 or later. It 
+* Python 2.6 or later, 3.2 or later, PyPy 2.0 or later, PyPy3 2.3 or later. It
   is the only non-optional requirement.
 
   .. warning:
-     It is highly advised to use UCS-4 version of Python because UCS-2 version 
-     uses significantly slower text processing (length determination and 
-     non-printable character replacement) functions due to the need of 
-     supporting unicode characters above U+FFFF which are represented as 
-     surrogate pairs. This price will be paid even if configuration has no such 
+     It is highly advised to use UCS-4 version of Python because UCS-2 version
+     uses significantly slower text processing (length determination and
+     non-printable character replacement) functions due to the need of
+     supporting unicode characters above U+FFFF which are represented as
+     surrogate pairs. This price will be paid even if configuration has no such
      characters.
 
-* C compiler. Required to build powerline client on linux. If it is not present 
+* C compiler. Required to build powerline client on linux. If it is not present
   then powerline will fall back to shell script or python client.
-* ``socat`` program. Required for shell variant of client which runs a bit 
+* ``socat`` program. Required for shell variant of client which runs a bit
   faster than python version of the client, but still slower than C version.
-* ``psutil`` python package. Required for some segments like cpu_percent. Some 
+* ``psutil`` python package. Required for some segments like cpu_percent. Some
   segments have linux-only fallbacks for ``psutil`` functionality.
 * ``hglib`` python package *and* mercurial executable. Required to work with
   mercurial repositories.
-* ``pygit2`` python package or ``git`` executable. Required to work with ``git`` 
+* ``pygit2`` python package or ``git`` executable. Required to work with ``git``
   repositories.
-* ``bzr`` python package (note: *not* standalone executable). Required to work 
+* ``bzr`` python package (note: *not* standalone executable). Required to work
   with bazaar repositories.
-* ``pyuv`` python package. Required for :ref:`libuv-based watcher 
+* ``pyuv`` python package. Required for :ref:`libuv-based watcher
   <config-common-watcher>` to work.
 * ``i3ipc`` python package. Required for i3wm bindings and segments.
-* ``xrandr`` program. Required for the multi-monitor lemonbar binding and the 
+* ``xrandr`` program. Required for the multi-monitor lemonbar binding and the
   :py:func:`powerline.listers.i3wm.output_lister`.
 
 .. note::
@@ -41,87 +41,97 @@ Generic requirements
 .. _repository-root:
 
 .. note::
-   When using ``pip``, the ``{repository_root}`` directory referenced in 
-   documentation may be found using ``pip show powerline-status``. In the output 
-   of ``pip show`` there is a line like ``Location: {path}``, that ``{path}`` is 
-   ``{repository_root}``. Unless it is ``--editable`` installation this is only 
-   applicable for ``{repository_root}/powerline/…`` paths: something like 
+   When using ``pip``, the ``{repository_root}`` directory referenced in
+   documentation may be found using ``pip show powerline-status``. In the output
+   of ``pip show`` there is a line like ``Location: {path}``, that ``{path}`` is
+   ``{repository_root}``. Unless it is ``--editable`` installation this is only
+   applicable for ``{repository_root}/powerline/…`` paths: something like
    ``{repository_root}/scripts/powerline-render`` is not present.
 
-   When using other packages referenced paths may not exist, in this case refer 
+   When using other packages referenced paths may not exist, in this case refer
    to package documentation.
 
 Pip installation
 ================
 
-Due to a naming conflict with an unrelated project powerline is available on 
-PyPI under the ``powerline-status`` name:
+- To install the latest release, run:
 
-.. code-block:: sh
+  .. code-block:: sh
 
-    pip install powerline-status
+     pip install powerline-status
 
-is the preferred method because this will get the latest release. To get current 
-development version
+  .. note:: Due to a naming conflict with an unrelated project, Powerline
+     is available on PyPi under the ``powerline-status`` name.
 
-.. code-block:: sh
+- To install the current development version, run:
 
-    pip install --user git+git://github.com/powerline/powerline
+  .. code-block:: sh
 
-may be used. If powerline was already checked out into some directory
+     pip install --user git+git://github.com/powerline/powerline
 
-.. code-block:: sh
+- If powerline was already checked out into some directory
 
-    pip install --user --editable={path_to_powerline}
+  .. code-block:: sh
 
-is useful, but note that in this case ``pip`` will not install ``powerline`` 
-executable and something like
+     pip install --user --editable={path_to_powerline}
 
-.. code-block:: sh
+  .. note:: In this case ``pip`` will not install ``powerline``
+     executable. You might need to run:
 
-    ln -s {path_to_powerline}/scripts/powerline ~/.local/bin
+     .. code-block:: sh
 
-will have to be done (:file:`~/.local/bin` should be replaced with some path 
-present in ``$PATH``).
+        ln -s {path_to_powerline}/scripts/powerline ~/.local/bin
+
+     (:file:`~/.local/bin` should be replaced with some path
+     present in ``$PATH``).
 
 .. note::
-    If ISP blocks git protocol for some reason github also provides ``ssh`` 
-    (``git+ssh://git@github.com/powerline/powerline``) and ``https`` 
-    (``git+https://github.com/powerline/powerline``) protocols. ``git`` protocol 
-    should be the fastest, but least secure one though.
+   If your ISP blocks the git protocol for some reason, use the following
+   Github protocols:
+
+   - ``ssh``: ``git+ssh://git@github.com/powerline/powerline``
+   - ``https``: ``git+https://github.com/powerline/powerline``
+
+   The ``git`` protocol should be the fastest, but the least secure one.
 
 Fonts installation
 ==================
 
-Powerline uses several special glyphs to get the arrow effect and some custom 
-symbols for developers. This requires having either a symbol font or a patched 
-font installed in the system. The used application (e.g. terminal emulator) must 
-also either be configured to use patched fonts (in some cases even support it 
-because custom glyphs live in private use area which some applications reserve 
-for themselves) or support fontconfig for powerline to work properly with 
+Powerline uses several special glyphs to get the arrow effect and some custom
+symbols for developers. This requires having either a symbol font or a patched
+font installed in the system.
+
+The used application (e.g. terminal emulator) must
+also either be configured to use patched fonts (in some cases even support it
+because custom glyphs live in private use area which some applications reserve
+for themselves) or support fontconfig for powerline to work properly with
 powerline-specific glyphs.
 
-:ref:`24-bit color support <config-common-term_truecolor>` may be enabled if 
-used terminal emulator supports it (see :ref:`the terminal emulator support 
+:ref:`24-bit color support <config-common-term_truecolor>` may be enabled if
+used terminal emulator supports it (see :ref:`the terminal emulator support
 matrix <usage-terminal-emulators>`).
 
-There are basically two ways to get powerline glyphs displayed: use 
-:file:`PowerlineSymbols.otf` font as a fallback for one of the existing fonts or 
-install a patched font.
+There are 2 ways to get powerline glyphs displayed:
+
+#. Use :file:`PowerlineSymbols.otf` font as a fallback for one of the existing
+   fonts, or
+#. :ref:`Install a patched font <installation-patched-fonts>`.
 
 .. _installation-patched-fonts:
 
-Patched fonts
--------------
+Installing patched fonts
+------------------------
 
 This method is the fallback method and works for every terminal.
 
-Download the font from `powerline-fonts`_. If preferred font can’t be found in 
-the `powerline-fonts`_ repo, then patching the preferred font is needed instead.
+#. Download the font from `powerline-fonts`_.
+#. Find the font you wish to use and install it following the repo's readme.
+
+   If the preferred fonts can’t be found in the `powerline-fonts`_ repo,
+   then patching the preferred font is needed.
 
 .. _powerline-fonts: https://github.com/powerline/fonts
 
-After downloading this font refer to platform-specific instructions.
 
 Installation on various platforms
 =================================

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -1,23 +1,25 @@
+.. _install-linux:
+
 *********************
 Installation on Linux
 *********************
 
-The following distribution-specific packages are officially supported, and they 
-provide an easy way of installing and upgrading Powerline. The packages will 
+The following distribution-specific packages are officially supported, and they
+provide an easy way of installing and upgrading Powerline. The packages will
 automatically do most of the configuration.
 
 * `Arch Linux (AUR), Python 2 version <https://aur.archlinux.org/packages/python2-powerline-git/>`_
 * `Arch Linux (AUR), Python 3 version <https://aur.archlinux.org/packages/python-powerline-git/>`_
 * Gentoo Live ebuild in `raiagent <https://github.com/leycec/raiagent>`_ overlay
-* Powerline package is available for Debian starting from Wheezy (via `backports 
-  <https://packages.debian.org/wheezy-backports/powerline>`_). Use `search 
-  <https://packages.debian.org/search?keywords=powerline&searchon=names&suite=all&section=all>`_ 
+* Powerline package is available for Debian starting from Wheezy (via `backports
+  <https://packages.debian.org/wheezy-backports/powerline>`_). Use `search
+  <https://packages.debian.org/search?keywords=powerline&searchon=names&suite=all&section=all>`_
   to get more information.
 
-If used distribution does not have an official package installation guide below 
+If used distribution does not have an official package installation guide below
 should be followed:
 
-1. Install Python 3.2+, Python 2.6+ or PyPy and ``pip`` with ``setuptools``. 
+1. Install Python 3.2+, Python 2.6+ or PyPy and ``pip`` with ``setuptools``.
    This step is distribution-specific, so no commands provided.
 2. Install Powerline using one of the following commands:
 
@@ -37,9 +39,9 @@ should be followed:
       named ``powerline-status`` in PyPI.
 
    .. note::
-      Powerline developers should be aware that``pip install --editable`` does 
-      not currently fully work. Installation performed this way are missing 
-      ``powerline`` executable that needs to be symlinked. It will be located in 
+      Powerline developers should be aware that``pip install --editable`` does
+      not currently fully work. Installation performed this way are missing
+      ``powerline`` executable that needs to be symlinked. It will be located in
       ``scripts/powerline``.
 
 Fonts installation
@@ -48,8 +50,8 @@ Fonts installation
 Fontconfig
 ----------
 
-This method only works on Linux. It’s the second recommended method if terminal 
-emulator supports it as patching fonts is not needed, and it generally works 
+This method only works on Linux. It’s the second recommended method if terminal
+emulator supports it as patching fonts is not needed, and it generally works
 with any coding font.
 
 #. Download the latest version of the symbol font and fontconfig file::
@@ -57,54 +59,54 @@ with any coding font.
       wget https://github.com/powerline/powerline/raw/develop/font/PowerlineSymbols.otf
       wget https://github.com/powerline/powerline/raw/develop/font/10-powerline-symbols.conf
 
-#. Move the symbol font to a valid X font path. Valid font paths can be 
+#. Move the symbol font to a valid X font path. Valid font paths can be
    listed with ``xset q``::
 
       mv PowerlineSymbols.otf ~/.local/share/fonts/
 
-#. Update font cache for the path the font was moved to (root priveleges may be 
+#. Update font cache for the path the font was moved to (root priveleges may be
    needed to update cache for the system-wide paths)::
 
       fc-cache -vf ~/.local/share/fonts/
 
-#. Install the fontconfig file. For newer versions of fontconfig the config 
-   path is ``~/.config/fontconfig/conf.d/``, for older versions it’s  
+#. Install the fontconfig file. For newer versions of fontconfig the config
+   path is ``~/.config/fontconfig/conf.d/``, for older versions it’s
    ``~/.fonts.conf.d/``::
 
       mv 10-powerline-symbols.conf ~/.config/fontconfig/conf.d/
 
-If custom symbols still cannot be seen then try closing all instances of the 
+If custom symbols still cannot be seen then try closing all instances of the
 terminal emulator. Restarting X may be needed for the changes to take effect.
 
-If custom symbols *still* can’t be seen, double-check that the font have been 
-installed to a valid X font path, and that the fontconfig file was installed to 
-a valid fontconfig path. Alternatively try to install a :ref:`patched font 
+If custom symbols *still* can’t be seen, double-check that the font have been
+installed to a valid X font path, and that the fontconfig file was installed to
+a valid fontconfig path. Alternatively try to install a :ref:`patched font
 <installation-patched-fonts>`.
 
 Patched font installation
 -------------------------
 
-This is the preferred method, but it is not always available because not all 
+This is the preferred method, but it is not always available because not all
 fonts were patched and not all fonts *can* be patched due to licensing issues.
 
 After downloading font the following should be done:
 
-#. Move the patched font to a valid X font path. Valid font paths can be 
+#. Move the patched font to a valid X font path. Valid font paths can be
    listed with ``xset q``::
 
       mv 'SomeFont for Powerline.otf' ~/.local/share/fonts/
 
-#. Update font cache for the path the font was moved to (root privileges may be 
+#. Update font cache for the path the font was moved to (root privileges may be
    needed for updating font cache for some paths)::
 
       fc-cache -vf ~/.local/share/fonts/
 
-After installing patched font terminal emulator, GVim or whatever application 
-powerline should work with must be configured to use the patched font. The 
+After installing patched font terminal emulator, GVim or whatever application
+powerline should work with must be configured to use the patched font. The
 correct font usually ends with *for Powerline*.
 
-If custom symbols cannot be seen then try closing all instances of the terminal 
+If custom symbols cannot be seen then try closing all instances of the terminal
 emulator. X server may need to be restarted for the changes to take effect.
 
-If custom symbols *still* can’t be seen then double-check that the font have 
+If custom symbols *still* can’t be seen then double-check that the font have
 been installed to a valid X font path.

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -4,22 +4,22 @@
 Installation on Linux
 *********************
 
-The following distribution-specific packages are officially supported, and they
-provide an easy way of installing and upgrading Powerline. The packages will
+The following distribution-specific packages are officially supported, and they 
+provide an easy way of installing and upgrading Powerline. The packages will 
 automatically do most of the configuration.
 
 * `Arch Linux (AUR), Python 2 version <https://aur.archlinux.org/packages/python2-powerline-git/>`_
 * `Arch Linux (AUR), Python 3 version <https://aur.archlinux.org/packages/python-powerline-git/>`_
 * Gentoo Live ebuild in `raiagent <https://github.com/leycec/raiagent>`_ overlay
-* Powerline package is available for Debian starting from Wheezy (via `backports
-  <https://packages.debian.org/wheezy-backports/powerline>`_). Use `search
-  <https://packages.debian.org/search?keywords=powerline&searchon=names&suite=all&section=all>`_
+* Powerline package is available for Debian starting from Wheezy (via `backports 
+  <https://packages.debian.org/wheezy-backports/powerline>`_). Use `search 
+  <https://packages.debian.org/search?keywords=powerline&searchon=names&suite=all&section=all>`_ 
   to get more information.
 
-If used distribution does not have an official package installation guide below
+If used distribution does not have an official package installation guide below 
 should be followed:
 
-1. Install Python 3.2+, Python 2.6+ or PyPy and ``pip`` with ``setuptools``.
+1. Install Python 3.2+, Python 2.6+ or PyPy and ``pip`` with ``setuptools``. 
    This step is distribution-specific, so no commands provided.
 2. Install Powerline using one of the following commands:
 
@@ -35,13 +35,13 @@ should be followed:
 
    will get the latest development version.
 
-   .. note:: Due to the naming conflict with an unrelated project powerline is
+   .. note:: Due to the naming conflict with an unrelated project powerline is 
       named ``powerline-status`` in PyPI.
 
    .. note::
-      Powerline developers should be aware that``pip install --editable`` does
-      not currently fully work. Installation performed this way are missing
-      ``powerline`` executable that needs to be symlinked. It will be located in
+      Powerline developers should be aware that``pip install --editable`` does 
+      not currently fully work. Installation performed this way are missing 
+      ``powerline`` executable that needs to be symlinked. It will be located in 
       ``scripts/powerline``.
 
 Fonts installation
@@ -50,8 +50,8 @@ Fonts installation
 Fontconfig
 ----------
 
-This method only works on Linux. It’s the second recommended method if terminal
-emulator supports it as patching fonts is not needed, and it generally works
+This method only works on Linux. It’s the second recommended method if terminal 
+emulator supports it as patching fonts is not needed, and it generally works 
 with any coding font.
 
 #. Download the latest version of the symbol font and fontconfig file::
@@ -59,27 +59,27 @@ with any coding font.
       wget https://github.com/powerline/powerline/raw/develop/font/PowerlineSymbols.otf
       wget https://github.com/powerline/powerline/raw/develop/font/10-powerline-symbols.conf
 
-#. Move the symbol font to a valid X font path. Valid font paths can be
+#. Move the symbol font to a valid X font path. Valid font paths can be 
    listed with ``xset q``::
 
       mv PowerlineSymbols.otf ~/.local/share/fonts/
 
-#. Update font cache for the path the font was moved to (root priveleges may be
+#. Update font cache for the path the font was moved to (root privileges may be 
    needed to update cache for the system-wide paths)::
 
       fc-cache -vf ~/.local/share/fonts/
 
-#. Install the fontconfig file. For newer versions of fontconfig the config
-   path is ``~/.config/fontconfig/conf.d/``, for older versions it’s
+#. Install the fontconfig file. For newer versions of fontconfig the config 
+   path is ``~/.config/fontconfig/conf.d/``, for older versions it’s 
    ``~/.fonts.conf.d/``::
 
       mv 10-powerline-symbols.conf ~/.config/fontconfig/conf.d/
 
-If custom symbols still cannot be seen then try closing all instances of the
+If custom symbols still cannot be seen then try closing all instances of the 
 terminal emulator. Restarting X may be needed for the changes to take effect.
 
-If custom symbols *still* can’t be seen, double-check that the font have been
-installed to a valid X font path, and that the fontconfig file was installed to
+If custom symbols *still* can’t be seen, double-check that the font have been 
+installed to a valid X font path, and that the fontconfig file was installed to 
 a valid fontconfig path. Alternatively try to install a :ref:`patched font
 <installation-patched-fonts>`.
 
@@ -91,22 +91,22 @@ fonts were patched and not all fonts *can* be patched due to licensing issues.
 
 After downloading font the following should be done:
 
-#. Move the patched font to a valid X font path. Valid font paths can be
+#. Move the patched font to a valid X font path. Valid font paths can be 
    listed with ``xset q``::
 
       mv 'SomeFont for Powerline.otf' ~/.local/share/fonts/
 
-#. Update font cache for the path the font was moved to (root privileges may be
+#. Update font cache for the path the font was moved to (root privileges may be 
    needed for updating font cache for some paths)::
 
       fc-cache -vf ~/.local/share/fonts/
 
-After installing patched font terminal emulator, GVim or whatever application
-powerline should work with must be configured to use the patched font. The
+After installing patched font terminal emulator, GVim or whatever application 
+powerline should work with must be configured to use the patched font. The 
 correct font usually ends with *for Powerline*.
 
-If custom symbols cannot be seen then try closing all instances of the terminal
+If custom symbols cannot be seen then try closing all instances of the terminal 
 emulator. X server may need to be restarted for the changes to take effect.
 
-If custom symbols *still* can’t be seen then double-check that the font have
+If custom symbols *still* can’t be seen then double-check that the font have 
 been installed to a valid X font path.

--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -1,67 +1,81 @@
+.. _install-osx:
+
 ********************
 Installation on OS X
 ********************
 
-Python package
-==============
+Installing Python
+=================
 
-1. Install a proper Python version (see `issue #39 
-   <https://github.com/powerline/powerline/issues/39>`_ for a discussion 
-   regarding the required Python version on OS X)::
+#. Install a proper Python version (see `issue #39
+   <https://github.com/powerline/powerline/issues/39>`_ for a discussion
+   regarding the required Python version on OS X).
+
+   Use either::
 
        sudo port select python python27-apple
 
-   Homebrew may be used here::
+   Or Homebrew::
 
        brew install python
 
    .. note::
-      In case :file:`powerline.sh` as a client ``socat`` and ``coreutils`` need 
-      to be installed. ``coreutils`` may be installed using ``brew install 
+      In case you use :file:`powerline.sh` as a client, install ``socat`` and
+      ``coreutils``. ``coreutils`` may be installed using ``brew install
       coreutils``.
 
-2. Install Powerline using one of the following commands:
-
-   .. code-block:: sh
-
-       pip install --user powerline-status
-
-   will get current release version and
-
-   .. code-block:: sh
-
-       pip install --user git+git://github.com/powerline/powerline
-
-   will get latest development version.
+#. Install Powerline using one of the following commands:
 
    .. warning::
       When using ``brew install`` to install Python one must not supply
       ``--user`` flag to ``pip``.
 
    .. note::
-      Due to the naming conflict with an unrelated project powerline is named 
+      Due to the naming conflict with an unrelated project, powerline is named
       ``powerline-status`` in PyPI.
 
+   - Latest version:
+
+     .. code-block:: sh
+
+        pip install --user powerline-status
+
+   - Development version:
+
+     .. code-block:: sh
+
+        pip install --user git+git://github.com/powerline/powerline
+
+
    .. note::
-      Powerline developers should be aware that ``pip install --editable`` does 
-      not currently fully work. Installation performed this way are missing 
-      ``powerline`` executable that needs to be symlinked. It will be located in 
+      Powerline developers should be aware that ``pip install --editable`` does
+      not currently fully work. Installation performed this way are missing
+      ``powerline`` executable that needs to be symlinked. It will be located in
       ``scripts/powerline``.
 
-Vim installation
+Installing vim
+==============
+
+Any terminal vim version with Python 3.2+ or Python 2.6+ support should work.
+
+If you use MacVim, install it using the following command:
+
+.. code-block:: sh
+
+   brew install macvim --env-std --with-override-system-vim
+
+Installing fonts
 ================
 
-Any terminal vim version with Python 3.2+ or Python 2.6+ support should work, 
-but MacVim users need to install it using the following command::
+To install a patched font:
 
-    brew install macvim --env-std --with-override-system-vim
+#. Download the font from the `powerline-fonts`_ repository.
+#. Double-click the patched font file in Finder. Patched fonts end with
+   *for Powerline*.
+#. Click :guilabel:`Install this font` in the preview window.
+#. Configure your terminal/MacVim/whatever application powerline should work
+   with to use the patched font.
 
-Fonts installation
-==================
+Powerline is still not enabled. Refer to :ref:`usage` to enable it.
 
-To install patched font double-click the font file in Finder, then click 
-:guilabel:`Install this font` in the preview window.
-
-After installing the patched font MacVim or terminal emulator (whatever 
-application powerline should work with) need to be configured to use the patched 
-font. The correct font usually ends with *for Powerline*.
+.. _powerline-fonts: https://github.com/powerline/fonts

--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -7,8 +7,8 @@ Installation on OS X
 Installing Python
 =================
 
-#. Install a proper Python version (see `issue #39
-   <https://github.com/powerline/powerline/issues/39>`_ for a discussion
+#. Install a proper Python version (see `issue #39 
+   <https://github.com/powerline/powerline/issues/39>`_ for a discussion 
    regarding the required Python version on OS X).
 
    Use either::
@@ -20,18 +20,18 @@ Installing Python
        brew install python
 
    .. note::
-      In case you use :file:`powerline.sh` as a client, install ``socat`` and
-      ``coreutils``. ``coreutils`` may be installed using ``brew install
+      In case you use :file:`powerline.sh` as a client, install ``socat`` and 
+      ``coreutils``. ``coreutils`` may be installed using ``brew install 
       coreutils``.
 
 #. Install Powerline using one of the following commands:
 
    .. warning::
-      When using ``brew install`` to install Python one must not supply
+      When using ``brew install`` to install Python one must not supply 
       ``--user`` flag to ``pip``.
 
    .. note::
-      Due to the naming conflict with an unrelated project, powerline is named
+      Due to the naming conflict with an unrelated project, powerline is named 
       ``powerline-status`` in PyPI.
 
    - Latest version:
@@ -48,9 +48,9 @@ Installing Python
 
 
    .. note::
-      Powerline developers should be aware that ``pip install --editable`` does
-      not currently fully work. Installation performed this way are missing
-      ``powerline`` executable that needs to be symlinked. It will be located in
+      Powerline developers should be aware that ``pip install --editable`` does 
+      not currently fully work. Installation performed this way are missing 
+      ``powerline`` executable that needs to be symlinked. It will be located in 
       ``scripts/powerline``.
 
 Installing vim
@@ -69,11 +69,11 @@ Installing fonts
 
 To install a patched font:
 
-#. Download the font from the `powerline-fonts`_ repository.
-#. Double-click the patched font file in Finder. Patched fonts end with
+#. Download the font from the `powerline-fonts`_ repository. 
+#. Double-click the patched font file in Finder. Patched fonts end with 
    *for Powerline*.
-#. Click :guilabel:`Install this font` in the preview window.
-#. Configure your terminal/MacVim/whatever application powerline should work
+#. Click :guilabel:`Install this font` in the preview window. 
+#. Configure your terminal/MacVim/whatever application powerline should work 
    with to use the patched font.
 
 Powerline is still not enabled. Refer to :ref:`usage` to enable it.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -19,29 +19,29 @@ To check if your version of vim supports Python, run:
    vim --version | grep +python
 
 
-If no mention of ``+python`` is shown in the command result, Vim needs to be
-recompiled with Python support. To do this see this `Stackexchange thread`_
+If no mention of ``+python`` is shown in the command result, Vim needs to be 
+recompiled with Python support. To do this see this `Stackexchange thread`_ 
 and the `Vim wiki`_.
 
 .. _`Stackexchange thread`: https://vi.stackexchange.com/questions/11526/how-to-enable-python-feature-in-vim
 .. _`Vim wiki`: http://vim.wikia.com/wiki/Building_Vim
 
-Vim version 7.4 or newer is recommended for performance reasons, but Powerline
+Vim version 7.4 or newer is recommended for performance reasons, but Powerline 
 supports Vim 7.0.112 and higher.
 
 Shell prompts requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Due to fish having incorrect code for prompt width calculations up to version
-2.1 and no way to tell that certain sequence of characters has no width
-(``%{…%}`` in zsh and ``\[…\]`` in bash prompts serve exactly this purpose)
-users that have fish versions below 2.1 are not supported..
+Due to fish having incorrect code for prompt width calculations up to version 
+2.1 and no way to tell that certain sequence of characters has no width 
+(``%{…%}`` in zsh and ``\[…\]`` in bash prompts serve exactly this purpose) 
+users that have fish versions below 2.1 are not supported.
 
 
 WM widgets requirements
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Awesome is supported starting from version 3.5.1, inclusive. QTile is supported
+Awesome is supported starting from version 3.5.1, inclusive. QTile is supported 
 from version 0.6, inclusive.
 
 .. _usage-terminal-emulators:
@@ -49,12 +49,12 @@ from version 0.6, inclusive.
 Terminal emulator requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Powerline uses several special glyphs to get the arrow effect and some custom
-symbols for developers. This requires either a symbol font or a patched font
-installed. Used terminal emulator must also support either patched fonts or
+Powerline uses several special glyphs to get the arrow effect and some custom 
+symbols for developers. This requires either a symbol font or a patched font 
+installed. Used terminal emulator must also support either patched fonts or 
 fontconfig for Powerline to work properly.
 
-:ref:`24-bit color support <config-common-term_truecolor>` can also be enabled
+:ref:`24-bit color support <config-common-term_truecolor>` can also be enabled 
 if terminal emulator supports it.
 
 .. table:: Application/terminal emulator feature support matrix

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,3 +1,5 @@
+.. _usage:
+
 *****
 Usage
 *****
@@ -8,32 +10,38 @@ Application-specific requirements
 Vim plugin requirements
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The vim plugin requires a vim version with Python support compiled in. Presence 
-of Python support in Vim can be checked by running ``vim --version | grep 
-+python``.
+The vim plugin requires a vim version with Python support compiled in.
 
-If Python support is absent then Vim needs to be compiled with it. To do this 
-use ``--enable-pythoninterp`` :file:`./configure` flag (Python 3 uses 
-``--enable-python3interp`` flag instead). Note that this also requires the 
-related Python headers to be installed. Please consult distribution’s 
-documentation for details on how to compile and install packages.
+To check if your version of vim supports Python, run:
 
-Vim version 7.4 or newer is recommended for performance reasons, but Powerline 
+.. code-block:: sh
+
+   vim --version | grep +python
+
+
+If no mention of ``+python`` is shown in the command result, Vim needs to be
+recompiled with Python support. To do this see this `Stackexchange thread`_
+and the `Vim wiki`_.
+
+.. _`Stackexchange thread`: https://vi.stackexchange.com/questions/11526/how-to-enable-python-feature-in-vim
+.. _`Vim wiki`: http://vim.wikia.com/wiki/Building_Vim
+
+Vim version 7.4 or newer is recommended for performance reasons, but Powerline
 supports Vim 7.0.112 and higher.
 
 Shell prompts requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Due to fish having incorrect code for prompt width calculations up to version 
-2.1 and no way to tell that certain sequence of characters has no width 
-(``%{…%}`` in zsh and ``\[…\]`` in bash prompts serve exactly this purpose) 
+Due to fish having incorrect code for prompt width calculations up to version
+2.1 and no way to tell that certain sequence of characters has no width
+(``%{…%}`` in zsh and ``\[…\]`` in bash prompts serve exactly this purpose)
 users that have fish versions below 2.1 are not supported..
 
 
 WM widgets requirements
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Awesome is supported starting from version 3.5.1, inclusive. QTile is supported 
+Awesome is supported starting from version 3.5.1, inclusive. QTile is supported
 from version 0.6, inclusive.
 
 .. _usage-terminal-emulators:
@@ -41,19 +49,19 @@ from version 0.6, inclusive.
 Terminal emulator requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Powerline uses several special glyphs to get the arrow effect and some custom 
-symbols for developers. This requires either a symbol font or a patched font 
-installed. Used terminal emulator must also support either patched fonts or 
+Powerline uses several special glyphs to get the arrow effect and some custom
+symbols for developers. This requires either a symbol font or a patched font
+installed. Used terminal emulator must also support either patched fonts or
 fontconfig for Powerline to work properly.
 
-:ref:`24-bit color support <config-common-term_truecolor>` can also be enabled 
+:ref:`24-bit color support <config-common-term_truecolor>` can also be enabled
 if terminal emulator supports it.
 
 .. table:: Application/terminal emulator feature support matrix
    :name: term-feature-support-matrix
 
    ===================== ======= ===================== ===================== =====================
-   Name                  OS      Patched font support  Fontconfig support    24-bit color support 
+   Name                  OS      Patched font support  Fontconfig support    24-bit color support
    ===================== ======= ===================== ===================== =====================
    Gvim                  Linux   |i_yes|               |i_no|                |i_yes|
    iTerm2                OS X    |i_yes|               |i_no|                |i_no|

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -61,7 +61,7 @@ if terminal emulator supports it.
    :name: term-feature-support-matrix
 
    ===================== ======= ===================== ===================== =====================
-   Name                  OS      Patched font support  Fontconfig support    24-bit color support
+   Name                  OS      Patched font support  Fontconfig support    24-bit color support 
    ===================== ======= ===================== ===================== =====================
    Gvim                  Linux   |i_yes|               |i_no|                |i_yes|
    iTerm2                OS X    |i_yes|               |i_no|                |i_no|

--- a/docs/source/usage/shell-prompts.rst
+++ b/docs/source/usage/shell-prompts.rst
@@ -5,7 +5,7 @@ Shell prompts
 *************
 
 .. note::
-    Powerline daemon is not run automatically by any of my bindings. It is 
+    Powerline daemon is not run automatically by any of my bindings. It is
     advised to add
 
     .. code-block:: bash
@@ -17,32 +17,38 @@ Shell prompts
 Bash prompt
 ===========
 
-Add the following line to the :file:`bashrc`, where ``{repository_root}`` is the 
-absolute path to the Powerline installation directory (see :ref:`repository root 
-<repository-root>`):
+#. Make sure you know your repository root. See
+   :ref:`repository root <repository-root>`.
+#. Add the following line to the :file:`bashrc`, where ``{repository_root}``
+   is the absolute path to the Powerline installation directory :
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   . {repository_root}/powerline/bindings/bash/powerline.sh
+      . {repository_root}/powerline/bindings/bash/powerline.sh
+
+   For example:
+   ``/usr/local/lib/python2.7/site-packages/powerline/bindings/bash/powerline.sh``
+
+#. (Optional but recommended) Add the following code to your :file:`bashrc`
+   before the call to ``powerline.sh``:
+
+   .. code-block:: bash
+
+      powerline-daemon -q
+      POWERLINE_BASH_CONTINUATION=1
+      POWERLINE_BASH_SELECT=1
 
 .. note::
-    Since without powerline daemon bash bindings are very slow PS2 
-    (continuation) and PS3 (select) prompts are not set up. Thus it is advised 
-    to use
+   Without the powerline daemon bash bindings are very slow, PS2
+   (continuation) and PS3 (select) prompts are not set up.
 
-    .. code-block:: bash
-
-       powerline-daemon -q
-       POWERLINE_BASH_CONTINUATION=1
-       POWERLINE_BASH_SELECT=1
-       . {repository_root}/powerline/bindings/bash/powerline.sh
-
-    in the bash configuration file. Without ``POWERLINE_BASH_*`` variables PS2 
-    and PS3 prompts are computed exactly once at bash startup.
+.. note::
+   Without ``POWERLINE_BASH_*`` variables PS2 and PS3 prompts are computed
+   exactly once at bash startup.
 
 .. warning::
-    At maximum bash continuation PS2 and select PS3 prompts are computed each 
-    time main PS1 prompt is computed. Thus putting e.g. current time into PS2 or 
+    At maximum bash continuation PS2 and select PS3 prompts are computed each
+    time main PS1 prompt is computed. Thus putting e.g. current time into PS2 or
     PS3 prompt will not work as expected.
 
     At minimum they are computed once on startup.
@@ -50,8 +56,8 @@ absolute path to the Powerline installation directory (see :ref:`repository root
 Zsh prompt
 ==========
 
-Add the following line to the :file:`zshrc`, where ``{repository_root}`` is the 
-absolute path to the Powerline installation directory (see :ref:`repository root 
+Add the following line to the :file:`zshrc`, where ``{repository_root}`` is the
+absolute path to the Powerline installation directory (see :ref:`repository root
 <repository-root>`):
 
 .. code-block:: bash
@@ -61,8 +67,8 @@ absolute path to the Powerline installation directory (see :ref:`repository root
 Fish prompt
 ===========
 
-Add the following line to :file:`config.fish`, where ``{repository_root}`` is 
-the absolute path to the Powerline installation directory (see :ref:`repository 
+Add the following line to :file:`config.fish`, where ``{repository_root}`` is
+the absolute path to the Powerline installation directory (see :ref:`repository
 root <repository-root>`):
 
 .. code-block:: bash
@@ -75,23 +81,23 @@ root <repository-root>`):
 Rcsh prompt
 ===========
 
-Powerline supports Plan9 rc reimplementation *by Byron Rakitzis* packaged by 
+Powerline supports Plan9 rc reimplementation *by Byron Rakitzis* packaged by
 many \*nix distributions. To use it add
 
 .. code-block:: bash
 
    . {repository_root}/powerline/bindings/rc/powerline.rc
 
-(``{repository_root}`` is the absolute path to the Powerline installation 
-directory, see :ref:`repository root <repository-root>`) to :file:`rcrc` file 
-(usually :file:`~/.rcrc`) and make sure ``rc`` is started as a login shell (with 
+(``{repository_root}`` is the absolute path to the Powerline installation
+directory, see :ref:`repository root <repository-root>`) to :file:`rcrc` file
+(usually :file:`~/.rcrc`) and make sure ``rc`` is started as a login shell (with
 ``-l`` argument): otherwise this configuration file is not read.
 
 .. warning::
-   Original Plan9 shell and its \*nix port are not supported because they are 
-   missing ``prompt`` special function (it is being called once before each 
-   non-continuation prompt). Since powerline could not support shell without 
-   this or equivalent feature some other not-so-critical features of that port 
+   Original Plan9 shell and its \*nix port are not supported because they are
+   missing ``prompt`` special function (it is being called once before each
+   non-continuation prompt). Since powerline could not support shell without
+   this or equivalent feature some other not-so-critical features of that port
    were used.
 
 Busybox (ash), mksh and dash prompt
@@ -103,10 +109,10 @@ After launching busybox run the following command:
 
    . {repository_root}/powerline/bindings/shell/powerline.sh
 
-where ``{repository_root}`` is the absolute path to the Powerline installation 
+where ``{repository_root}`` is the absolute path to the Powerline installation
 directory (see :ref:`repository root <repository-root>`).
 
-Mksh users may put this line into ``~/.mkshrc`` file. Dash users may use the 
+Mksh users may put this line into ``~/.mkshrc`` file. Dash users may use the
 following in ``~/.profile``:
 
 .. code-block:: bash
@@ -116,29 +122,29 @@ following in ``~/.profile``:
     fi
 
 .. note::
-    Dash users that already have ``$ENV`` defined should either put the ``. 
-    …/shell/powerline.sh`` line in the ``$ENV`` file or create a new file which 
-    will source (using ``.`` command) both former ``$ENV`` file and 
+    Dash users that already have ``$ENV`` defined should either put the ``.
+    …/shell/powerline.sh`` line in the ``$ENV`` file or create a new file which
+    will source (using ``.`` command) both former ``$ENV`` file and
     :file:`powerline.sh` files and set ``$ENV`` to the path of this new file.
 
 .. warning::
-    Mksh users have to set ``$POWERLINE_SHELL_CONTINUATION`` and 
-    ``$POWERLINE_SHELL_SELECT`` to 1 to get PS2 and PS3 (continuation and 
-    select) prompts support respectively: as command substitution is not 
-    performed in these shells for these prompts they are updated once each time 
+    Mksh users have to set ``$POWERLINE_SHELL_CONTINUATION`` and
+    ``$POWERLINE_SHELL_SELECT`` to 1 to get PS2 and PS3 (continuation and
+    select) prompts support respectively: as command substitution is not
+    performed in these shells for these prompts they are updated once each time
     PS1 prompt is displayed which may be slow.
 
-    It is also known that while PS2 and PS3 update is triggered at PS1 update it 
-    is *actually performed* only *next* time PS1 is displayed which means that 
+    It is also known that while PS2 and PS3 update is triggered at PS1 update it
+    is *actually performed* only *next* time PS1 is displayed which means that
     PS2 and PS3 prompts will be outdated and may be incorrect for this reason.
 
-    Without these variables PS2 and PS3 prompts will be set once at startup. 
+    Without these variables PS2 and PS3 prompts will be set once at startup.
     This only touches mksh users: busybox and dash both have no such problem.
 
 .. warning::
-    Job count is using some weird hack that uses signals and temporary files for 
+    Job count is using some weird hack that uses signals and temporary files for
     interprocess communication. It may be wrong sometimes. Not the case in mksh.
 
 .. warning::
-    Busybox has two shells: ``ash`` and ``hush``. Second is known to segfault in 
+    Busybox has two shells: ``ash`` and ``hush``. Second is known to segfault in
     busybox 1.22.1 when using :file:`powerline.sh` script.

--- a/docs/source/usage/shell-prompts.rst
+++ b/docs/source/usage/shell-prompts.rst
@@ -5,7 +5,7 @@ Shell prompts
 *************
 
 .. note::
-    Powerline daemon is not run automatically by any of my bindings. It is
+    Powerline daemon is not run automatically by any of my bindings. It is 
     advised to add
 
     .. code-block:: bash
@@ -17,19 +17,19 @@ Shell prompts
 Bash prompt
 ===========
 
-#. Make sure you know your repository root. See
+#. Make sure you know your repository root. See 
    :ref:`repository root <repository-root>`.
-#. Add the following line to the :file:`bashrc`, where ``{repository_root}``
+#. Add the following line to the :file:`bashrc`, where ``{repository_root}`` 
    is the absolute path to the Powerline installation directory :
 
    .. code-block:: bash
 
       . {repository_root}/powerline/bindings/bash/powerline.sh
 
-   For example:
+   For example: 
    ``/usr/local/lib/python2.7/site-packages/powerline/bindings/bash/powerline.sh``
 
-#. (Optional but recommended) Add the following code to your :file:`bashrc`
+#. (Optional but recommended) Add the following code to your :file:`bashrc` 
    before the call to ``powerline.sh``:
 
    .. code-block:: bash
@@ -38,17 +38,17 @@ Bash prompt
       POWERLINE_BASH_CONTINUATION=1
       POWERLINE_BASH_SELECT=1
 
-.. note::
-   Without the powerline daemon bash bindings are very slow, PS2
+.. note:: 
+   Without the powerline daemon bash bindings are very slow, PS2 
    (continuation) and PS3 (select) prompts are not set up.
 
-.. note::
-   Without ``POWERLINE_BASH_*`` variables PS2 and PS3 prompts are computed
+.. note:: 
+   Without ``POWERLINE_BASH_*`` variables PS2 and PS3 prompts are computed 
    exactly once at bash startup.
 
 .. warning::
-    At maximum bash continuation PS2 and select PS3 prompts are computed each
-    time main PS1 prompt is computed. Thus putting e.g. current time into PS2 or
+    At maximum bash continuation PS2 and select PS3 prompts are computed each 
+    time main PS1 prompt is computed. Thus putting e.g. current time into PS2 or 
     PS3 prompt will not work as expected.
 
     At minimum they are computed once on startup.
@@ -56,8 +56,8 @@ Bash prompt
 Zsh prompt
 ==========
 
-Add the following line to the :file:`zshrc`, where ``{repository_root}`` is the
-absolute path to the Powerline installation directory (see :ref:`repository root
+Add the following line to the :file:`zshrc`, where ``{repository_root}`` is the 
+absolute path to the Powerline installation directory (see :ref:`repository root 
 <repository-root>`):
 
 .. code-block:: bash
@@ -67,8 +67,8 @@ absolute path to the Powerline installation directory (see :ref:`repository root
 Fish prompt
 ===========
 
-Add the following line to :file:`config.fish`, where ``{repository_root}`` is
-the absolute path to the Powerline installation directory (see :ref:`repository
+Add the following line to :file:`config.fish`, where ``{repository_root}`` is 
+the absolute path to the Powerline installation directory (see :ref:`repository 
 root <repository-root>`):
 
 .. code-block:: bash
@@ -81,23 +81,23 @@ root <repository-root>`):
 Rcsh prompt
 ===========
 
-Powerline supports Plan9 rc reimplementation *by Byron Rakitzis* packaged by
+Powerline supports Plan9 rc reimplementation *by Byron Rakitzis* packaged by  
 many \*nix distributions. To use it add
 
 .. code-block:: bash
 
    . {repository_root}/powerline/bindings/rc/powerline.rc
 
-(``{repository_root}`` is the absolute path to the Powerline installation
-directory, see :ref:`repository root <repository-root>`) to :file:`rcrc` file
-(usually :file:`~/.rcrc`) and make sure ``rc`` is started as a login shell (with
+(``{repository_root}`` is the absolute path to the Powerline installation 
+directory, see :ref:`repository root <repository-root>`) to :file:`rcrc` file 
+(usually :file:`~/.rcrc`) and make sure ``rc`` is started as a login shell (with 
 ``-l`` argument): otherwise this configuration file is not read.
 
 .. warning::
-   Original Plan9 shell and its \*nix port are not supported because they are
-   missing ``prompt`` special function (it is being called once before each
-   non-continuation prompt). Since powerline could not support shell without
-   this or equivalent feature some other not-so-critical features of that port
+   Original Plan9 shell and its \*nix port are not supported because they are 
+   missing ``prompt`` special function (it is being called once before each 
+   non-continuation prompt). Since powerline could not support shell without 
+   this or equivalent feature some other not-so-critical features of that port 
    were used.
 
 Busybox (ash), mksh and dash prompt
@@ -109,10 +109,10 @@ After launching busybox run the following command:
 
    . {repository_root}/powerline/bindings/shell/powerline.sh
 
-where ``{repository_root}`` is the absolute path to the Powerline installation
+where ``{repository_root}`` is the absolute path to the Powerline installation 
 directory (see :ref:`repository root <repository-root>`).
 
-Mksh users may put this line into ``~/.mkshrc`` file. Dash users may use the
+Mksh users may put this line into ``~/.mkshrc`` file. Dash users may use the 
 following in ``~/.profile``:
 
 .. code-block:: bash
@@ -122,29 +122,29 @@ following in ``~/.profile``:
     fi
 
 .. note::
-    Dash users that already have ``$ENV`` defined should either put the ``.
-    …/shell/powerline.sh`` line in the ``$ENV`` file or create a new file which
-    will source (using ``.`` command) both former ``$ENV`` file and
+    Dash users that already have ``$ENV`` defined should either put the ``. 
+    …/shell/powerline.sh`` line in the ``$ENV`` file or create a new file which 
+    will source (using ``.`` command) both former ``$ENV`` file and 
     :file:`powerline.sh` files and set ``$ENV`` to the path of this new file.
 
 .. warning::
-    Mksh users have to set ``$POWERLINE_SHELL_CONTINUATION`` and
-    ``$POWERLINE_SHELL_SELECT`` to 1 to get PS2 and PS3 (continuation and
-    select) prompts support respectively: as command substitution is not
-    performed in these shells for these prompts they are updated once each time
+    Mksh users have to set ``$POWERLINE_SHELL_CONTINUATION`` and 
+    ``$POWERLINE_SHELL_SELECT`` to 1 to get PS2 and PS3 (continuation and 
+    select) prompts support respectively: as command substitution is not 
+    performed in these shells for these prompts they are updated once each time 
     PS1 prompt is displayed which may be slow.
 
-    It is also known that while PS2 and PS3 update is triggered at PS1 update it
-    is *actually performed* only *next* time PS1 is displayed which means that
+    It is also known that while PS2 and PS3 update is triggered at PS1 update it 
+    is *actually performed* only *next* time PS1 is displayed which means that 
     PS2 and PS3 prompts will be outdated and may be incorrect for this reason.
 
-    Without these variables PS2 and PS3 prompts will be set once at startup.
+    Without these variables PS2 and PS3 prompts will be set once at startup. 
     This only touches mksh users: busybox and dash both have no such problem.
 
 .. warning::
-    Job count is using some weird hack that uses signals and temporary files for
+    Job count is using some weird hack that uses signals and temporary files for 
     interprocess communication. It may be wrong sometimes. Not the case in mksh.
 
 .. warning::
-    Busybox has two shells: ``ash`` and ``hush``. Second is known to segfault in
+    Busybox has two shells: ``ash`` and ``hush``. Second is known to segfault in 
     busybox 1.22.1 when using :file:`powerline.sh` script.

--- a/docs/source/usage/shell-prompts.rst
+++ b/docs/source/usage/shell-prompts.rst
@@ -81,7 +81,7 @@ root <repository-root>`):
 Rcsh prompt
 ===========
 
-Powerline supports Plan9 rc reimplementation *by Byron Rakitzis* packaged by  
+Powerline supports Plan9 rc reimplementation *by Byron Rakitzis* packaged by 
 many \*nix distributions. To use it add
 
 .. code-block:: bash


### PR DESCRIPTION
Hello, 

As a new user of Powerline, which I find great, I had issues with the install docs and I had to use other online tutorials to set it up.

I'm opening a first PR to submit readability updates to the installation page and the OSX install/bash sections. 
I would be happy to send in deeper updates to the docs if you find it useful, and potentially improve the navigation of the docs.

For the review, I suggest checking the output directly, as proof reading docs on Github is pretty tedious when blocks of text have been moved around.
