### PR TITLE
Add socket activation support

### DIFF
--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -42,6 +42,17 @@ should be followed:
       ``powerline`` executable that needs to be symlinked. It will be located in 
       ``scripts/powerline``.
 
+
+Service installation
+===================
+
+Copy ``powerline-daemon.service`` and ``powerline-daemon.socket`` from ``powerline/dist/systemd``
+to ``~/.config/systemd/user`` (per-user) or ``/etc/systemd/user`` (all users).
+
+Then execute ``systemctl --user daemon-reload`` to make systemd aware of the new units and
+run ``systemctl --user enable --now powerline-daemon.socket`` to have ``powerline-daemon``
+automatically run whenever needed.
+
 Fonts installation
 ==================
 

--- a/docs/source/tips-and-tricks.rst
+++ b/docs/source/tips-and-tricks.rst
@@ -59,7 +59,8 @@ Once you have updated powerline you generally have the following options:
    work if the application uses ``powerline-daemon``.
 #. For shell and tmux bindings (except for zsh with libzpython): do not do 
    anything if you do not use ``powerline-daemon``, run ``powerline-daemon 
-   --replace`` if you do.
+   --replace`` if you do or ``systemctl --user stop powerline-daemon`` on
+   Linux/systemd environments, it will be auto-restarted.
 #. Use powerline reloading feature.
 
     .. warning::

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -192,7 +192,9 @@ I am suffering bad lags before displaying shell prompt
 
 To get rid of these lags there currently are two options:
 
-* Run ``powerline-daemon``. Powerline does not automatically start it for you.
+* Run ``powerline-daemon``. Powerline does not automatically start it for you
+  (unless the systemd units were installed/enabled according to the Linux
+  installation documentation).
 * Compile and install ``libzpython`` module that lives in 
   https://bitbucket.org/ZyX_I/zpython. This variant is zsh-specific.
 

--- a/docs/source/usage/other.rst
+++ b/docs/source/usage/other.rst
@@ -102,7 +102,8 @@ root <repository-root>`)::
 
         run-shell "powerline-daemon -q"
 
-    to :file:`.tmux.conf`.
+    to :file:`.tmux.conf`, unless the systemd units were installed/enabled
+    according to the Linux installation documentation.
 
 .. warning::
     Segments which depend on current working directory (e.g. 

--- a/docs/source/usage/shell-prompts.rst
+++ b/docs/source/usage/shell-prompts.rst
@@ -40,6 +40,9 @@ absolute path to the Powerline installation directory (see :ref:`repository root
     in the bash configuration file. Without ``POWERLINE_BASH_*`` variables PS2 
     and PS3 prompts are computed exactly once at bash startup.
 
+    In case the systemd units were installed/enabled according to the Linux
+    installation documentation, omit the `powerline-daemon -q` line.
+
 .. warning::
     At maximum bash continuation PS2 and select PS3 prompts are computed each 
     time main PS1 prompt is computed. Thus putting e.g. current time into PS2 or 

--- a/powerline/dist/systemd/powerline-daemon.service
+++ b/powerline/dist/systemd/powerline-daemon.service
@@ -5,6 +5,3 @@ Documentation=https://powerline.readthedocs.org/en/latest/
 
 [Service]
 ExecStart=/usr/bin/powerline-daemon --foreground
-
-[Install]
-WantedBy=default.target

--- a/powerline/dist/systemd/powerline-daemon.socket
+++ b/powerline/dist/systemd/powerline-daemon.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=Socket for powerline-daemon
+
+[Socket]
+ListenStream=@powerline-ipc-%U
+
+[Install]
+WantedBy=default.target

--- a/scripts/powerline-daemon
+++ b/scripts/powerline-daemon
@@ -361,13 +361,16 @@ def check_existing(address):
 		except EnvironmentError:
 			pass
 
-	sock = socket.socket(family=socket.AF_UNIX)
 	try:
-		sock.bind(address)
-	except socket.error as e:
-		if getattr(e, 'errno', None) == errno.EADDRINUSE:
-			return None
-		raise
+		sock = socket.fromfd(3, socket.AF_UNIX, socket.SOCK_STREAM)
+	except socket.error as fdse:
+		sock = socket.socket(family=socket.AF_UNIX)
+		try:
+			sock.bind(address)
+		except socket.error as e:
+			if getattr(e, 'errno', None) == errno.EADDRINUSE:
+				return None
+			raise
 	return sock
 
 


### PR DESCRIPTION
This allows to auto-start the powerline-daemon using FD-passing/socket activation, so the `powerline-daemon.socket` unit maintains powerline's AF_UNIX stream socket and takes care of starting `powerline-daemon` whenever it is needed - no more having to start it in each and every integration (shell profile, `tmux.conf`, etc).