### PR TITLE
Fix divider background color for tmux solarized

### DIFF
--- a/powerline/config_files/colorschemes/solarized.json
+++ b/powerline/config_files/colorschemes/solarized.json
@@ -9,7 +9,7 @@
 		"critical:failure":           { "fg": "solarized:base3", "bg": "solarized:red", "attrs": [] },
 		"critical:success":           { "fg": "solarized:base3", "bg": "solarized:green", "attrs": [] },
 		"background":                 { "fg": "solarized:base3", "bg": "solarized:base02", "attrs": [] },
-		"background:divider":         { "fg": "solarized:base1", "bg": "solarized:base02", "attrs": [] },
+		"background:divider":         { "fg": "solarized:base1", "bg": "solarized:base03", "attrs": [] },
 		"user":                       { "fg": "solarized:base3", "bg": "solarized:blue", "attrs": ["bold"] },
 		"virtualenv":                 { "fg": "solarized:base3", "bg": "solarized:green", "attrs": [] },
 		"branch":                     { "fg": "solarized:base1", "bg": "solarized:base02", "attrs": [] },


### PR DESCRIPTION
Current settings leads to the following under tmux (on the right side):
<img width="450" alt="Screen Shot 2019-03-11 at 16 22 15" src="https://user-images.githubusercontent.com/2215778/54138169-3f688480-441f-11e9-8127-a95e150e2ec6.png">

After this modification, it looks like:
<img width="448" alt="Screen Shot 2019-03-11 at 16 22 28" src="https://user-images.githubusercontent.com/2215778/54138192-498a8300-441f-11e9-84d0-88620225ef6f.png">
