### PR TITLE
Defensive decode of vim.options['encoding'] in py3

### DIFF
--- a/powerline/bindings/vim/__init__.py
+++ b/powerline/bindings/vim/__init__.py
@@ -22,7 +22,8 @@ if (
 			return vim.options['encoding'] or 'ascii'
 	else:
 		def get_vim_encoding():
-			return vim.options['encoding'].decode('ascii') or 'ascii'
+			encoding = vim.options['encoding'] or 'ascii'
+			return encoding if isinstance(encoding, str) else encoding.decode('ascii')
 elif hasattr(vim, 'eval'):
 	def get_vim_encoding():
 		return vim.eval('&encoding') or 'ascii'


### PR DESCRIPTION
This change is defensive against the possibility that in some versions/environments the encoding is bytes instead of a string.

This is in response to the following exception (also seen in #1999):
```
Traceback (most recent call last):
  File "<string>", line 53, in <module>
  File "<string>", line 40, in powerline_troubleshoot
  File "/usr/lib/python3/dist-packages/powerline/lint/__init__.py", line 12, in <module>
    from powerline.segments.vim import vim_modes
  File "/usr/lib/python3/dist-packages/powerline/segments/vim/__init__.py", line 16, in <module>
    from powerline.bindings.vim import (vim_get_func, getbufvar, vim_getbufoption,
  File "/usr/lib/python3/dist-packages/powerline/bindings/vim/__init__.py", line 44, in <module>
    vim_encoding = get_vim_encoding()
  File "/usr/lib/python3/dist-packages/powerline/bindings/vim/__init__.py", line 25, in get_vim_encoding
    return vim.options['encoding'].decode('ascii') or 'ascii'
AttributeError: 'str' object has no attribute 'decode
```

Which might just be down to using neovim, as I haven't tested on vim with python3