### PR TITLE
Extend documentation for bash

### DIFF
--- a/docs/source/usage/shell-prompts.rst
+++ b/docs/source/usage/shell-prompts.rst
@@ -39,6 +39,14 @@ absolute path to the Powerline installation directory (see :ref:`repository root
 
     in the bash configuration file. Without ``POWERLINE_BASH_*`` variables PS2 
     and PS3 prompts are computed exactly once at bash startup.
+    
+    In the case you are using a rolling linux distribution, where python version
+    can change quite often or if you are sharing multiple the same config files
+    across multiple machines, the ``{{repository-root}}`` could be set like this:
+    
+    .. code-block:: bash
+       PYTHON_SITE_PATH=$(python -m site --user-site)
+       . $PYTHON_SITE_PATH/powerline/bindings/bash/powerline.sh
 
 .. warning::
     At maximum bash continuation PS2 and select PS3 prompts are computed each 


### PR DESCRIPTION
When using a system that is updated frequently the user could find the situation where the path to the repository root has changed but the python binary is looking somewhere else (e.g, Python gets an upgrade from 3.6 to 3.7) or if the same bashrc is shared among different machines with different versions of python (2.x, 3.x and so on), is useful to be able to get one consistent way to figure out
what would be the path.