### PR TITLE
Add "[BOM]" (byte-order-mark) text in file encoding info

### DIFF
--- a/powerline/segments/vim/__init__.py
+++ b/powerline/segments/vim/__init__.py
@@ -343,14 +343,16 @@ def file_format(pl, segment_info):
 @requires_segment_info
 @add_divider_highlight_group('background:divider')
 def file_encoding(pl, segment_info):
-	'''Return file encoding/character set.
+	'''Return file encoding/character set. With a "[BOM]" flag added if the file has a byte-order-mark
 
-	:return: file encoding/character set or None if unknown or missing file encoding
+	:return: file encoding/character set (optionally with "[BOM]" flag) or None if unknown or missing file encoding
 
 	Divider highlight group used: ``background:divider``.
 	'''
-	return vim_getbufoption(segment_info, 'fileencoding') or None
-
+	bomstr = vim_getbufoption(segment_info, 'fileencoding') or None
+	if bomstr and vim_getbufoption(segment_info, 'bomb'):
+		bomstr = bomstr + '[BOM]'
+	return bomstr
 
 @requires_segment_info
 @add_divider_highlight_group('background:divider')

--- a/powerline/segments/vim/__init__.py
+++ b/powerline/segments/vim/__init__.py
@@ -351,7 +351,7 @@ def file_encoding(pl, segment_info):
 	'''
 	bomstr = vim_getbufoption(segment_info, 'fileencoding') or None
 	if bomstr and vim_getbufoption(segment_info, 'bomb'):
-		bomstr = bomstr + '[BOM]'
+		bomstr = bomstr + ''
 	return bomstr
 
 @requires_segment_info


### PR DESCRIPTION
Like in vim-airline
See https://github.com/vim-airline/vim-airline/pull/992 and https://github.com/vim-airline/vim-airline/commit/fdb74f549df6972185daf1fa22fe3647e092b71a

Ref #2015