### PR TITLE
Fix #2013; Improve fish binding

### DIFF
--- a/powerline/bindings/fish/powerline-setup.fish
+++ b/powerline/bindings/fish/powerline-setup.fish
@@ -1,5 +1,5 @@
 function powerline-setup
-	function _powerline_columns_fallback
+	function _powerline_columns
 		if which stty >/dev/null
 			if stty size >/dev/null
 				stty size | cut -d' ' -f2
@@ -8,17 +8,6 @@ function powerline-setup
 		end
 		echo 0
 		return 0
-	end
-
-	function _powerline_columns
-		# Hack: `test "" -eq 0` is true, as well as `test 0 -eq 0`
-		# Note: at fish startup `$COLUMNS` is equal to zero, meaning that it may 
-		# not be used.
-		if test "$COLUMNS" -eq 0
-			_powerline_columns_fallback
-		else
-			echo "$COLUMNS"
-		end
 	end
 
 	if test -z "$POWERLINE_CONFIG_COMMAND"
@@ -44,7 +33,7 @@ function powerline-setup
 			set -l addargs "--last-exit-code=\$status"
 			set -l addargs "$addargs --last-pipe-status=\$status"
 			set -l addargs "$addargs --jobnum=(jobs -p | wc -l)"
-			# One random value has an 1/32767 = 0.0031% probability of having 
+			# One random value has an 1/32767 = 0.0031% probability of having
 			# the same value in two shells
 			set -l addargs "$addargs --renderer-arg=client_id="(random)
 			set -l addargs "$addargs --width=\$_POWERLINE_COLUMNS"

--- a/powerline/bindings/fish/powerline-setup.fish
+++ b/powerline/bindings/fish/powerline-setup.fish
@@ -59,6 +59,8 @@ function powerline-setup
 				env \$POWERLINE_COMMAND $POWERLINE_COMMAND_ARGS shell right $addargs
 				$rpromptpast
 			end
+            function fish_mode_prompt
+            end
 			function _powerline_set_columns --on-signal WINCH
 				set -g _POWERLINE_COLUMNS $columnsexpr
 			end


### PR DESCRIPTION
* Fixes #2013 by implementing the function `fish_mode_prompt` in the fish binding.
* Remove hacky (and buggy) `_powerline_columns` and replace it by `_powerline_columns_fallback`