### PR TITLE
Parse out letters in maj. version string

### DIFF
--- a/powerline/bindings/tmux/__init__.py
+++ b/powerline/bindings/tmux/__init__.py
@@ -79,6 +79,7 @@ def get_tmux_version(pl):
 	if version_string == 'master':
 		return TmuxVersionInfo(float('inf'), 0, version_string)
 	major, minor = version_string.split('.')
+	major = NON_DIGITS.subn('', major)[0]
 	suffix = DIGITS.subn('', minor)[0] or None
 	minor = NON_DIGITS.subn('', minor)[0]
 	return TmuxVersionInfo(int(major), int(minor), suffix)


### PR DESCRIPTION
Fixes issue caused by tmux version naming changing from `3.0-rc` to `next-3.1`, caused by this commit: https://github.com/tmux/tmux/commit/e7a530fe4c0f8e0f807daf6a1b80d86c67c93e1b

This is for issue #1992 

With that version, the version is in an unexpected format:
```
bbyers ~ $ tmux -V
tmux next-3.1
```
Causing an error when powerline attempts to return an in for the major version number:
```
 bbyers ~ $ powerline-config tmux setup
Traceback (most recent call last):
  File "/home/bbyers/.local/bin/powerline-config", line 22, in <module>
    args.function(pl, args)
  File "/home/bbyers/.local/lib/python3.5/site-packages/powerline/commands/config.py", line 15, in __call__
    self.function(*args, **kwargs)
  File "/home/bbyers/.local/lib/python3.5/site-packages/powerline/bindings/config.py", line 184, in tmux_setup
    tmux_version = get_tmux_version(pl)
  File "/home/bbyers/.local/lib/python3.5/site-packages/powerline/bindings/tmux/__init__.py", line 84, in get_tmux_version
    return TmuxVersionInfo(int(major), int(minor), suffix)
ValueError: invalid literal for int() with base 10: 'next-3'
```

This change parses out the letters from the major version, similar to what is done for the minor version.
