### PR TITLE
Updated uptime segment to have show time in a better way

### DIFF
--- a/powerline/segments/common/sys.py
+++ b/powerline/segments/common/sys.py
@@ -150,7 +150,7 @@ else:
 
 
 @add_divider_highlight_group('background:divider')
-def uptime(pl, days_format='{days:d}d', hours_format=' {hours:d}h', minutes_format=' {minutes:d}m', seconds_format=' {seconds:d}s', shorten_len=3):
+def uptime(pl, days_format='{:d}d', hours_format=' {:d}h', minutes_format=' {:02d}m', seconds_format=' {:02d}s', shorten_len=3):
 	'''Return system uptime.
 
 	:param str days_format:
@@ -174,10 +174,14 @@ def uptime(pl, days_format='{days:d}d', hours_format=' {hours:d}h', minutes_form
 	minutes, seconds = divmod(seconds, 60)
 	hours, minutes = divmod(minutes, 60)
 	days, hours = divmod(hours, 24)
-	time_formatted = list(filter(None, [
-		days_format.format(days=days) if days and days_format else None,
-		hours_format.format(hours=hours) if hours and hours_format else None,
-		minutes_format.format(minutes=minutes) if minutes and minutes_format else None,
-		seconds_format.format(seconds=seconds) if seconds and seconds_format else None,
-	]))[0:shorten_len]
+	formats = [days_format, hours_format, minutes_format, seconds_format]
+	times = [days, hours, minutes, seconds]
+	show_number = False
+	time_formatted = []
+	for i in range(len(times)):
+		if times[i] != 0:
+			show_number = True
+		if show_number:
+			time_formatted.append(formats[i].format(times[i]))
+	time_formatted = time_formatted[:shorten_len]
 	return ''.join(time_formatted).strip()

--- a/powerline/segments/common/sys.py
+++ b/powerline/segments/common/sys.py
@@ -175,15 +175,12 @@ def uptime(pl, days_format='{days:d}d', hours_format=' {hours:d}h', minutes_form
 	minutes, seconds = divmod(seconds, 60)
 	hours, minutes = divmod(minutes, 60)
 	days, hours = divmod(hours, 24)
-	formats = [days_format, hours_format, minutes_format, seconds_format]
-	times = [(days, "days"), (hours, "hours"), (minutes, "minutes"), (seconds, "seconds")]
-	show_number = False
-	time_formatted = []
-	for i in range(len(times)):
-		current_time, str_name = times[i]
-		if current_time != 0:
-			show_number = True
-		if show_number:
-			time_formatted.append(formats[i].format(**{str_name: current_time}))
-	time_formatted = time_formatted[:shorten_len]
+	time_formatted = list(filter(None, [
+		days_format.format(days=days) if days_format else None,
+		hours_format.format(hours=hours) if hours_format else None,
+		minutes_format.format(minutes=minutes) if minutes_format else None,
+		seconds_format.format(seconds=seconds) if seconds_format else None,
+	]))
+	first_non_zero = next((i for i, x in enumerate([days, hours, minutes, seconds]) if x != 0))
+	time_formatted = time_formatted[first_non_zero:first_non_zero + shorten_len]
 	return ''.join(time_formatted).strip()

--- a/powerline/segments/common/sys.py
+++ b/powerline/segments/common/sys.py
@@ -150,7 +150,8 @@ else:
 
 
 @add_divider_highlight_group('background:divider')
-def uptime(pl, days_format='{:d}d', hours_format=' {:d}h', minutes_format=' {:02d}m', seconds_format=' {:02d}s', shorten_len=3):
+def uptime(pl, days_format='{days:d}d', hours_format=' {hours:d}h', minutes_format=' {minutes:02d}m',
+		seconds_format=' {seconds:02d}s', shorten_len=3):
 	'''Return system uptime.
 
 	:param str days_format:
@@ -175,13 +176,14 @@ def uptime(pl, days_format='{:d}d', hours_format=' {:d}h', minutes_format=' {:02
 	hours, minutes = divmod(minutes, 60)
 	days, hours = divmod(hours, 24)
 	formats = [days_format, hours_format, minutes_format, seconds_format]
-	times = [days, hours, minutes, seconds]
+	times = [(days, "days"), (hours, "hours"), (minutes, "minutes"), (seconds, "seconds")]
 	show_number = False
 	time_formatted = []
 	for i in range(len(times)):
-		if times[i] != 0:
+		current_time, str_name = times[i]
+		if current_time != 0:
 			show_number = True
 		if show_number:
-			time_formatted.append(formats[i].format(times[i]))
+			time_formatted.append(formats[i].format(**{str_name: current_time}))
 	time_formatted = time_formatted[:shorten_len]
 	return ''.join(time_formatted).strip()

--- a/tests/test_python/test_segments.py
+++ b/tests/test_python/test_segments.py
@@ -831,10 +831,10 @@ class TestSys(TestCommon):
 	def test_uptime(self):
 		pl = Pl()
 		with replace_attr(self.module, '_get_uptime', lambda: 259200):
-			self.assertEqual(self.module.uptime(pl=pl), [{'contents': '3d', 'divider_highlight_group': 'background:divider'}])
+			self.assertEqual(self.module.uptime(pl=pl), [{'contents': '3d 0h 00m', 'divider_highlight_group': 'background:divider'}])
 		with replace_attr(self.module, '_get_uptime', lambda: 93784):
-			self.assertEqual(self.module.uptime(pl=pl), [{'contents': '1d 2h 3m', 'divider_highlight_group': 'background:divider'}])
-			self.assertEqual(self.module.uptime(pl=pl, shorten_len=4), [{'contents': '1d 2h 3m 4s', 'divider_highlight_group': 'background:divider'}])
+			self.assertEqual(self.module.uptime(pl=pl), [{'contents': '1d 2h 03m', 'divider_highlight_group': 'background:divider'}])
+			self.assertEqual(self.module.uptime(pl=pl, shorten_len=4), [{'contents': '1d 2h 03m 04s', 'divider_highlight_group': 'background:divider'}])
 		with replace_attr(self.module, '_get_uptime', lambda: 65536):
 			self.assertEqual(self.module.uptime(pl=pl), [{'contents': '18h 12m 16s', 'divider_highlight_group': 'background:divider'}])
 			self.assertEqual(self.module.uptime(pl=pl, shorten_len=2), [{'contents': '18h 12m', 'divider_highlight_group': 'background:divider'}])


### PR DESCRIPTION
This mainly addresses #1859 and provides a reasonable standard way of showing the uptime.

Now, this format
 - Does show a time units with 0 as long as there are bigger time units (e.g. will show 0 seconds if there are minutes but not days if your uptime is below a day)
 - Shows 2 digits for seconds and minutes and thereby prevents frequent changes in size here (I didn't add that for hours because I think these 2 size changes/day are not distracting)

I would be happy if this could get merged and finds it way into the repo