### PR TITLE
latest homebrew needs two more dashes in install command

### DIFF
--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -54,7 +54,7 @@ Vim installation
 Any terminal vim version with Python 3.2+ or Python 2.6+ support should work, 
 but MacVim users need to install it using the following command::
 
-    brew install macvim --env-std --with-override-system-vim
+    brew install macvim -- --env-std --with-override-system-vim
 
 Fonts installation
 ==================


### PR DESCRIPTION
latest brew version only passes install options with two dashes, see https://github.com/Homebrew/homebrew-core/issues/31510 and https://github.com/skwp/dotfiles/issues/817\#issuecomment-496861257