### PR TITLE
Update Powerline for ipython >=7

### DIFF
--- a/docs/source/usage/other.rst
+++ b/docs/source/usage/other.rst
@@ -130,6 +130,46 @@ root <repository-root>`)::
 IPython prompt
 ==============
 
+For IPython>=7.0, add the following line to
+:file:`~/.ipython/profile_default/ipython_config.py` file in the used profile:
+
+
+.. code-block:: Python
+
+    from powerline.bindings.ipython.since_7 import PowerlinePrompts
+    c.TerminalInteractiveShell.prompts_class = PowerlinePrompts
+
+.. note::
+    If certain graphical/colored elements are not showing, make sure `c.TerminalInteractiveShell.simple_prompt`
+    is set to `False` in your config. 
+    Setting ``simple_prompt`` to False after IPython-5.0 is required regardless 
+    of whether you use ``c.InteractiveShellApp.extensions`` setting or 
+    ``c.TerminalInteractiveShell.prompts_class``. But you probably already have 
+    this line because ``simple_prompt`` is set to ``False`` by default and IPython
+    is not very useful without it.
+
+For IPython>=5.0 and <7.0 it is suggested to use
+
+.. code-block:: Python
+
+    from powerline.bindings.ipython.since_5 import PowerlinePrompts
+    c = get_config()
+    c.TerminalInteractiveShell.simple_prompt = False
+    c.TerminalInteractiveShell.prompts_class = PowerlinePrompts
+    
+
+    
+For IPython>=5.0 and <7.0 you may use the below set up, but it is deprecated.    
+For IPython>=0.11 add the following line to
+:file:`~/.ipython/profile_default/ipython_config.py` file in the used profile:
+
+.. code-block:: Python
+
+    c = get_config()
+    c.InteractiveShellApp.extensions = [
+        'powerline.bindings.ipython.post_0_11'
+    ]
+
 For IPython<0.11 add the following lines to :file:`.ipython/ipy_user_conf.py`:
 
 .. code-block:: Python
@@ -141,31 +181,6 @@ For IPython<0.11 add the following lines to :file:`.ipython/ipy_user_conf.py`:
     # create skeleton ipy_user_conf.py file):
     powerline_setup()
 
-For IPython>=0.11 add the following line to
-:file:`~/.ipython/profile_default/ipython_config.py` file in the used profile:
-
-.. code-block:: Python
-
-    c = get_config()
-    c.InteractiveShellApp.extensions = [
-        'powerline.bindings.ipython.post_0_11'
-    ]
-
-For IPython>=5.0 you may use the above set up, but it is deprecated. It is 
-suggested to use
-
-.. code-block:: Python
-
-    from powerline.bindings.ipython.since_5 import PowerlinePrompts
-    c = get_config()
-    c.TerminalInteractiveShell.simple_prompt = False
-    c.TerminalInteractiveShell.prompts_class = PowerlinePrompts
-
-.. note::
-    Setting ``simple_prompt`` to False after IPython-5.0 is required regardless 
-    of whether you use ``c.InteractiveShellApp.extensions`` setting or 
-    ``c.TerminalInteractiveShell.prompts_class``. But you probably already have 
-    this line because IPython is not very useful without it.
 
 IPython=0.11* is not supported and does not work. IPython<0.10 was not 
 tested (not installable by pip).

--- a/powerline/bindings/ipython/post_0_11.py
+++ b/powerline/bindings/ipython/post_0_11.py
@@ -1,5 +1,6 @@
 # vim:fileencoding=utf-8:noet
-from __future__ import (unicode_literals, division, absolute_import, print_function)
+from __future__ import (unicode_literals, division,
+                        absolute_import, print_function)
 
 from weakref import ref
 from warnings import warn
@@ -80,7 +81,7 @@ if has_prompt_manager:
 			if has_prompt_manager:
 				renderer_module = '.pre_5'
 			else:
-				renderer_module = '.since_5'
+				renderer_module = '.since_7'
 			super(ConfigurableIPythonPowerline, self).init(
 				renderer_module=renderer_module)
 
@@ -106,13 +107,15 @@ def load_ipython_extension(ip):
 		powerline = ConfigurableIPythonPowerline(ip)
 		powerline.setup(ip, shutdown_hook)
 	else:
-		from powerline.bindings.ipython.since_5 import PowerlinePrompts
+		from powerline.bindings.ipython.since_7 import PowerlinePrompts
 		ip.prompts_class = PowerlinePrompts
 		ip.prompts = PowerlinePrompts(ip)
 		warn(DeprecationWarning(
 			'post_0_11 extension is deprecated since IPython 5, use\n'
-			'  from powerline.bindings.ipython.since_5 import PowerlinePrompts\n'
+			'  from powerline.bindings.ipython.since_7 import PowerlinePrompts\n'
 			'  c.TerminalInteractiveShell.prompts_class = PowerlinePrompts\n'
+			'  or check: \n'
+			'  https://powerline.readthedocs.io/en/master/usage/other.html\n'
 		))
 
 

--- a/powerline/bindings/ipython/post_0_11.py
+++ b/powerline/bindings/ipython/post_0_11.py
@@ -114,8 +114,8 @@ def load_ipython_extension(ip):
 			'post_0_11 extension is deprecated since IPython 5, use\n'
 			'  from powerline.bindings.ipython.since_7 import PowerlinePrompts\n'
 			'  c.TerminalInteractiveShell.prompts_class = PowerlinePrompts\n'
-			'  or check: \n'
-			'  https://powerline.readthedocs.io/en/master/usage/other.html\n'
+			'or check: \n'
+			'https://powerline.readthedocs.io/en/master/usage/other.html\n'
 		))
 
 


### PR DESCRIPTION
The method used for `since_5` does not work, but `since_7` does, however it is not documented.

I personally haven't found `c = get_config()` to be useful once you have generated the default `~/.ipython/profile_default/ipython_config.py` file.

Since `c.TerminalInteractiveShell.simple_prompt` is set to `False` by default, it's not worth mentioning it.  There's many other things that **can** break if you change the default config options too.  Additionally, `simple_prompt=True` doesn't fatally break anything— just make things less pretty.  So it'd be better to not have that, but mention if things don't look pretty to make sure they didn't change that default.

Additionally updated `post_0_11.py` to use `since_7` (given that most people using a later version than 0.11 are probably using 7), and instructing users with issues (for example, those using version 5) to read the documentation for `since_5`.