### PR TITLE
Adding an indicator for Tim Pope's vim-obsession

### DIFF
--- a/powerline/config_files/colorschemes/vim/__main__.json
+++ b/powerline/config_files/colorschemes/vim/__main__.json
@@ -20,6 +20,7 @@
 		"winnr":              "information:unimportant",
 		"tabnr":              "file_directory",
 		"capslock_indicator": "paste_indicator",
+		"obsession_indicator": "information:unimportant",
 
 		"csv:column_number": "line_current",
 		"csv:column_name":   "line_current_symbol",

--- a/powerline/segments/vim/plugin/obsession.py
+++ b/powerline/segments/vim/plugin/obsession.py
@@ -1,0 +1,22 @@
+# vim:fileencoding=utf-8:noet
+from __future__ import (unicode_literals, division, absolute_import, print_function)
+
+try:
+	import vim
+except ImportError:
+	vim = object()
+
+from powerline.bindings.vim import vim_func_exists
+from powerline.theme import requires_segment_info
+
+
+@requires_segment_info
+def obsession_indicator(pl, segment_info, text='rec.'):
+	'''Shows the indicator if tpope/vim-obsession plugin is enabled
+
+	:param str text:
+		String to show when obsession is recording sessions.
+	'''
+	if not vim_func_exists('ObsessionStatus'):
+		return None
+	return text if vim.eval('ObsessionStatus("on","off")') == "on"  else None


### PR DESCRIPTION
I based it off the capslock indicator, and choose an unobtrusive colorscheme, in line with the plugin's philosophy, that the user shouldn't have to bother much with saving sessions, but I'm not sure that was a good choice in general.