### PR TITLE
Update to include default path to powerline_root for apt-get

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,8 @@ Configuration
 Basic powerline configuration is done via `JSON` files located at `.config/powerline/`. It is a good idea to start by copying the default configuration located at `powerline_root/powerline/config_files/` to `.config/powerline/`.
 If you installed the powerline from the AUR or via pip, `powerline_root` should be `/usr/lib/python3.6/site-packages/` or something similar, depending on your python version.
 
+If you installed powerline via apt-get 'powerline_root' should be '/usr/share/powerline/'.
+
 This should yield you the following directory structure:
 
     ::


### PR DESCRIPTION
This isn't super important and would be considered a low priority change - however there is a lot of people googling for the same answer that this one line could cover.