### PR TITLE
Added timezone support to time

### DIFF
--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import pytz
 
 
-def date(pl, format='%Y-%m-%d', istime=False, timezone=None, suffix=None):
+def date(pl, format='%Y-%m-%d', istime=False, timezone=None):
 	'''Return the current date.
 
 	:param str format:
@@ -20,9 +20,6 @@ def date(pl, format='%Y-%m-%d', istime=False, timezone=None, suffix=None):
 		see a full list by running `pytz.all_timezones` from your python
 		interpreter. If None is provided, this defaults to your local system's
 		timezone.
-	:param str suffix:
-		A string suffix to add at the end of the time string (after a space).
-		This is usually used to denote the timezone name.
 
 	Divider highlight group used: ``time:divider``.
 
@@ -34,9 +31,6 @@ def date(pl, format='%Y-%m-%d', istime=False, timezone=None, suffix=None):
 		contents = curr_time.strftime(format)
 	except UnicodeEncodeError:
 		contents = curr_time.strftime(format.encode('utf-8')).decode('utf-8')
-
-	if suffix:
-		contents += " " + suffix
 
 	return [{
 		'contents': contents,

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -1,25 +1,32 @@
 # vim:fileencoding=utf-8:noet
 from __future__ import (unicode_literals, division, absolute_import, print_function)
 
-from datetime import datetime
+from datetime import datetime, tzinfo
 
 
-def date(pl, format='%Y-%m-%d', istime=False):
+def date(pl, format='%Y-%m-%d', istime=False, timezone=None):
 	'''Return the current date.
 
 	:param str format:
 		strftime-style date format string
 	:param bool istime:
 		If true then segment uses ``time`` highlight group.
+	:param str timezone:
+		The name of the timezone to display (per the format used
+		by datetime.tzinfo.tzname():
+		https://docs.python.org/3/library/datetime.html#datetime.tzinfo.tzname).
+		If none is provided, will default to your local system's time
 
 	Divider highlight group used: ``time:divider``.
 
 	Highlight groups used: ``time`` or ``date``.
 	'''
+	curr_time = datetime.now(tz=None if not timezone else tzinfo.tzname(timezone))
+
 	try:
-		contents = datetime.now().strftime(format)
+		contents = curr_time.strftime(format)
 	except UnicodeEncodeError:
-		contents = datetime.now().strftime(format.encode('utf-8')).decode('utf-8')
+		contents = curr_time.strftime(format.encode('utf-8')).decode('utf-8')
 
 	return [{
 		'contents': contents,

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -34,8 +34,8 @@ def date(pl, format='%Y-%m-%d', istime=False, timezone=None, suffix=None):
 	except UnicodeEncodeError:
 		contents = curr_time.strftime(format.encode('utf-8')).decode('utf-8')
 
-	#if suffix:
-	#	contents += " " + suffix
+	if suffix:
+		contents += " " + suffix
 
 	return [{
 		'contents': contents,

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -2,6 +2,7 @@
 from __future__ import (unicode_literals, division, absolute_import, print_function)
 
 from datetime import datetime, tzinfo
+import pytz
 
 
 def date(pl, format='%Y-%m-%d', istime=False, timezone=None):
@@ -12,16 +13,18 @@ def date(pl, format='%Y-%m-%d', istime=False, timezone=None):
 	:param bool istime:
 		If true then segment uses ``time`` highlight group.
 	:param str timezone:
-		The name of the timezone to display (per the format used
-		by datetime.tzinfo.tzname():
-		https://docs.python.org/3/library/datetime.html#datetime.tzinfo.tzname).
-		If none is provided, will default to your local system's time
+		The name of the timezone to display (per the format used by pytz. This
+		includes long-form formats like "US/Pacific" or "Europe/Amsterdam",
+		as well as some timezone abbreviations like "UTC", "EET", etc. You can
+		see a full list by running `pytz.all_timezones` from your python
+		interpreter. If None is provided, this defaults to your local system's
+		timezone.
 
 	Divider highlight group used: ``time:divider``.
 
 	Highlight groups used: ``time`` or ``date``.
 	'''
-	curr_time = datetime.now(tz=None if not timezone else tzinfo.tzname(timezone))
+	curr_time = datetime.now(tz=None if not timezone else pytz.timezone(timezone))
 
 	try:
 		contents = curr_time.strftime(format)

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -1,7 +1,8 @@
 # vim:fileencoding=utf-8:noet
 from __future__ import (unicode_literals, division, absolute_import, print_function)
 
-from datetime import datetime, tzinfo
+from datetime import datetime
+
 import pytz
 
 

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -5,7 +5,7 @@ from datetime import datetime, tzinfo
 import pytz
 
 
-def date(pl, format='%Y-%m-%d', istime=False, timezone=None):
+def date(pl, format='%Y-%m-%d', istime=False, timezone=None, suffix=None):
 	'''Return the current date.
 
 	:param str format:
@@ -19,6 +19,9 @@ def date(pl, format='%Y-%m-%d', istime=False, timezone=None):
 		see a full list by running `pytz.all_timezones` from your python
 		interpreter. If None is provided, this defaults to your local system's
 		timezone.
+	:param str suffix:
+		A string suffix to add at the end of the time string (after a space).
+		This is usually used to denote the timezone name.
 
 	Divider highlight group used: ``time:divider``.
 
@@ -30,6 +33,9 @@ def date(pl, format='%Y-%m-%d', istime=False, timezone=None):
 		contents = curr_time.strftime(format)
 	except UnicodeEncodeError:
 		contents = curr_time.strftime(format.encode('utf-8')).decode('utf-8')
+
+	if suffix:
+		contents += " " + suffix
 
 	return [{
 		'contents': contents,
@@ -48,7 +54,7 @@ def fuzzy_time(pl, unicode_text=False):
 	'''Display the current time as fuzzy time, e.g. "quarter past six".
 
 	:param bool unicode_text:
-		If true then hyphenminuses (regular ASCII ``-``) and single quotes are 
+		If true then hyphenminuses (regular ASCII ``-``) and single quotes are
 		replaced with unicode dashes and apostrophes.
 	'''
 	hour_str = ['twelve', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven']

--- a/powerline/segments/common/time.py
+++ b/powerline/segments/common/time.py
@@ -34,8 +34,8 @@ def date(pl, format='%Y-%m-%d', istime=False, timezone=None, suffix=None):
 	except UnicodeEncodeError:
 		contents = curr_time.strftime(format.encode('utf-8')).decode('utf-8')
 
-	if suffix:
-		contents += " " + suffix
+	#if suffix:
+	#	contents += " " + suffix
 
 	return [{
 		'contents': contents,

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
 	packages=find_packages(exclude=('tests', 'tests.*')),
 	include_package_data=True,
 	zip_safe=False,
-	install_requires=['argparse'] if OLD_PYTHON else [],
+	install_requires=['pytz'] + (['argparse'] if OLD_PYTHON else []),
 	extras_require={
 		'docs': [
 			'Sphinx',


### PR DESCRIPTION
This adds support in the time segments to take in optional timezone and suffix parameters. This will allow users to display multiple time zones  on their powerline. This is especially useful on servers that are configured to have a standard timezone for ease of configuration (like UTC) but the user will be using the machine from a specific local timezone.