### PR TITLE
Render cpu_load_percent segment even when psutil returns 0.0

### DIFF
--- a/powerline/segments/common/sys.py
+++ b/powerline/segments/common/sys.py
@@ -90,8 +90,6 @@ try:
 					self.exception('Exception while calculating cpu_percent: {0}', str(e))
 
 		def render(self, cpu_percent, format='{0:.0f}%', **kwargs):
-			if not cpu_percent:
-				return None
 			return [{
 				'contents': format.format(cpu_percent),
 				'gradient_level': cpu_percent,


### PR DESCRIPTION
Although the docs for psutil say 0.0 is a nonsense value that's returned
first and supposed to be ignored, but on a relatively idle system it
will actually return 0.0 occasionally after that. So at the expense of
displaying that "nonsense value" when the statusbar first loads, this
change gets rid of the visual disruptions of having the segment pop out
and back in periodically.

Fixes #2110.