### PR TITLE
Implement GitHub actions for build and publish

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,46 @@
+name: Build and Publish to PyPI
+
+on:
+  push:
+    branches:
+    - master
+    - develop
+    - feature/actions
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Publish
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+        packages_dir: dist/


### PR DESCRIPTION
Requires a secret named PYPI_TOKEN containing a valid PyPI API token.

Note that this drop support for Python 2.6 as GitHub Actions only
supports Python 2.7+.

Fixes #2116