### PR TITLE
Prefer Python 3 in the Vim plugin

### DIFF
--- a/powerline/bindings/vim/plugin/powerline.vim
+++ b/powerline/bindings/vim/plugin/powerline.vim
@@ -26,14 +26,14 @@ if exists('g:powerline_pycmd')
 		let s:pyeval = g:powerline_pyeval
 		let s:has_python = 1
 	endif
-elseif has('python')
-	let s:has_python = 1
-	let s:pycmd = 'py'
-	let s:pyeval = get(g:, 'powerline_pyeval', 'pyeval')
 elseif has('python3')
 	let s:has_python = 1
 	let s:pycmd = 'py3'
 	let s:pyeval = get(g:, 'powerline_pyeval', 'py3eval')
+elseif has('python')
+	let s:has_python = 1
+	let s:pycmd = 'py'
+	let s:pyeval = get(g:, 'powerline_pyeval', 'pyeval')
 else
 	let s:has_python = 0
 endif


### PR DESCRIPTION
Python 2 is EOL, so it makes more sense to use Python 3 as the preferred version of Python rather than just fall back on it.