### PR TITLE
Fallback to a current window in tabline()

### DIFF
--- a/powerline/vim.py
+++ b/powerline/vim.py
@@ -262,6 +262,7 @@ class VimPowerline(Powerline):
 
 	def new_win_idx(self, window_id):
 		r = None
+
 		for window in vim.windows:
 			try:
 				curwindow_id = window.vars['powerline_window_id']
@@ -302,7 +303,18 @@ class VimPowerline(Powerline):
 		return self.render(window, window_id, winnr)
 
 	def tabline(self):
-		return self.render(*self.win_idx(None), is_tabline=True)
+		r = self.win_idx(None)
+
+		if r:
+		    return self.render(*r, is_tabline=True)
+		else:
+		    win = vim.current.window
+		    r = (
+			win,
+			win.vars.get('powerline_window_id', self.last_window_id),
+			win.number,
+		    )
+		    return self.render(*r, is_tabline=True)
 
 	def new_window(self):
 		return self.render(*self.win_idx(None))


### PR DESCRIPTION
Ref #2125

I looked at `statusline()`, and it seems that it tries to render a current window if `self.win_idx(None)`  returned `None`. So I did the same in `tabline()` for consistency.