### PR TITLE
docs: fix simple typo, proided -> provided

### DIFF
--- a/powerline/lint/spec.py
+++ b/powerline/lint/spec.py
@@ -163,7 +163,7 @@ class Spec(object):
 		'''Define message which will be used when unknown key was found
 
 		“Unknown” is a key that was not provided at the initialization and via 
-		:py:meth:`Spec.update` and did not match any ``keyfunc`` proided via 
+		:py:meth:`Spec.update` and did not match any ``keyfunc`` provided via 
 		:py:meth:`Spec.unknown_spec`.
 
 		:param msgfunc:


### PR DESCRIPTION
There is a small typo in powerline/lint/spec.py.

Should read `provided` rather than `proided`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md