### PR TITLE
Override player segment in case of inactive player

### DIFF
--- a/powerline/segments/common/players.py
+++ b/powerline/segments/common/players.py
@@ -37,7 +37,7 @@ def _convert_seconds(seconds):
 
 
 class PlayerSegment(Segment):
-	def __call__(self, format='{state_symbol} {artist} - {title} ({total})', state_symbols=STATE_SYMBOLS, **kwargs):
+	def __call__(self, format='{state_symbol} {artist} - {title} ({total})', state_symbols=STATE_SYMBOLS, player_inactive_override=None, **kwargs):
 		stats = {
 			'state': 'fallback',
 			'album': None,
@@ -51,8 +51,12 @@ class PlayerSegment(Segment):
 			return None
 		stats.update(func_stats)
 		stats['state_symbol'] = state_symbols.get(stats['state'])
+		player_string = format.format(**stats)
+		player_inactive = stats["state"] == "stop" and not stats["artist"] and not stats["title"]
+		if player_inactive and player_inactive_override is not None:
+			player_string = str(player_inactive_override)
 		return [{
-			'contents': format.format(**stats),
+			'contents': player_string,
 			'highlight_groups': ['player_' + (stats['state'] or 'fallback'), 'player'],
 		}]
 


### PR DESCRIPTION
Let's say if the player is stopped (means the player has no track queued), the player segment will still keep displaying the string consisting just of the player status symbol ("stop" symbol) and any other constants present in the `format` parameter.

With this commit, the new parameter `player_inactive_override` will take over the player segment display in cases where the player is stopped and with no tracks in queue.

If `player_inactive_override` is `None` (defaults), it will maintain the previous behaviour (backwards compatibility).

----------

In more detail, my `dbus_player` in tmux theme is configured as:
```json
    "right": [
        {
            "function": "powerline.segments.common.players.dbus_player",
            "priority": 20,
            "name": "player",
            "args": {
                "state_symbols": {
                    "play": " ",
                    "pause": "契",
                    "stop": "栗"
                },
                "format": "{state_symbol} {artist} - {title}",
                "player_name": "player"
            }
        }
    ]
```

It works very well except one case I've found:

For example, if I have YouTube playing in a chromium-based browser, the segment works well as seen in the pic:

![image](https://user-images.githubusercontent.com/20314742/103221183-0bd65180-4948-11eb-8dad-6d24ddfbd90f.png)

However, if I now close the YouTube tab and switch to some other tab, the segment would change to this:

![image](https://user-images.githubusercontent.com/20314742/103221428-9a4ad300-4948-11eb-87b7-0e709fab5aa2.png)

which looks ugly.

----------

With this PR, the new argument can be set with `player_inactive_override`, for example, setting it to an empty string on my previous config with:
```json
    "right": [
        {
            "function": "powerline.segments.common.players.dbus_player",
            "priority": 20,
            "name": "player",
            "args": {
                "state_symbols": {
                    "play": " ",
                    "pause": "契",
                    "stop": "栗"
                },
                "format": "{state_symbol} {artist} - {title}",
                "player_inactive_override": "",
                "player_name": "player"
            }
        },
```

It doesn't look ugly while indicating that the player (web-browser) is still running by displaying the background color (blue)!

![image](https://user-images.githubusercontent.com/20314742/103221560-f4e42f00-4948-11eb-80a4-d3d733b7237b.png)

This situation can happen with real media players too (instead of browsers) if they are idle (not playing media).