### PR TITLE
powerline.zsh: squelch which output.

### DIFF
--- a/powerline/bindings/zsh/powerline.zsh
+++ b/powerline/bindings/zsh/powerline.zsh
@@ -197,7 +197,7 @@ _powerline_add_widget() {
 }
 
 if test -z "${POWERLINE_CONFIG_COMMAND}" ; then
-	if which powerline-config >/dev/null ; then
+	if which powerline-config >/dev/null 2>/dev/null ; then
 		typeset -g POWERLINE_CONFIG_COMMAND=powerline-config
 	else
 		typeset -g POWERLINE_CONFIG_COMMAND="${_POWERLINE_SOURCED:h:h:h:h}/scripts/powerline-config"


### PR DESCRIPTION
If powerline-config isn't on $PATH, GNU which will output "no
powerline-config in ($PATH)" to stderr, which we previously weren't
silencing.