### PR TITLE
Fix outdated Github url

### DIFF
--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -30,7 +30,7 @@ Python package
 
    .. code-block:: sh
 
-       pip install --user git+git://github.com/powerline/powerline
+       pip install --user git+https://github.com/powerline/powerline
 
    will get latest development version.
 


### PR DESCRIPTION
git:// is deprecated from Github starting from Jan. 11th, 2022.
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git