### PR TITLE
Remove git protocol

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -66,7 +66,7 @@ development version
 
 .. code-block:: sh
 
-    pip install --user git+git://github.com/powerline/powerline
+    pip install --user git+https://github.com/powerline/powerline
 
 may be used. If powerline was already checked out into some directory
 
@@ -85,10 +85,9 @@ will have to be done (:file:`~/.local/bin` should be replaced with some path
 present in ``$PATH``).
 
 .. note::
-    If ISP blocks git protocol for some reason github also provides ``ssh`` 
-    (``git+ssh://git@github.com/powerline/powerline``) and ``https`` 
-    (``git+https://github.com/powerline/powerline``) protocols. ``git`` protocol 
-    should be the fastest, but least secure one though.
+    We can use either ``https``(``git+ssh://git@github.com/powerline/powerline``)
+    or ``https``(``git+https://github.com/powerline/powerline``) protocols.
+    ``git`` protocol is deprecated by Github.
 
 Fonts installation
 ==================

--- a/docs/source/installation/linux.rst
+++ b/docs/source/installation/linux.rst
@@ -29,7 +29,7 @@ should be followed:
 
    .. code-block:: sh
 
-      pip install --user git+git://github.com/powerline/powerline
+      pip install --user git+https://github.com/powerline/powerline
 
    will get the latest development version.
 

--- a/docs/source/installation/osx.rst
+++ b/docs/source/installation/osx.rst
@@ -30,7 +30,7 @@ Python package
 
    .. code-block:: sh
 
-       pip install --user git+git://github.com/powerline/powerline
+       pip install --user git+https://github.com/powerline/powerline
 
    will get latest development version.
 


### PR DESCRIPTION
Replace `git` protocols with `https` protocol.
git:// is deprecated from Github starting from Jan. 11th, 2022.
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git