### PR TITLE
Ignore tempfiles created by Mercurial VCS

### DIFF
--- a/powerline/lib/vcs/mercurial.py
+++ b/powerline/lib/vcs/mercurial.py
@@ -86,3 +86,8 @@ class Repository(object):
 			get_func=branch_name_from_config_file,
 			create_watcher=self.create_watcher,
 		)
+
+	@staticmethod
+	def ignore_event(path, name):
+		# Ignore temporary files created during mercurial commands
+		return path.endswith('.hg') and name.startswith(b'tmp')


### PR DESCRIPTION
Mercurial creates temporary files in the .hg directory while running certain commands. The creation of these should not invalidate the tree status cache for the repository.

Fixes #2206 