### PR TITLE
Fix two documentation errors/warnings

### DIFF
--- a/docs/source/develop/segments.rst
+++ b/docs/source/develop/segments.rst
@@ -531,7 +531,7 @@ i3wm
 	   the `i3-ipc` workspace object corresponding to this workspace.
 	   Contains string attributes ``name`` and ``output``, as well as boolean
 	   attributes for ``visible``, ``urgent`` and ``focused``. Currently only
-    provided by  the :py:func:`powerline.listers.i3wm.workspace_lister` lister.
+	   provided by  the :py:func:`powerline.listers.i3wm.workspace_lister` lister.
 
 Segment class
 =============

--- a/powerline/segments/common/env.py
+++ b/powerline/segments/common/env.py
@@ -21,6 +21,7 @@ def environment(pl, segment_info, variable=None):
 @requires_segment_info
 def virtualenv(pl, segment_info, ignore_venv=False, ignore_conda=False, ignored_names=("venv", ".venv")):
 	'''Return the name of the current Python or conda virtualenv.
+
 	:param list ignored_names:
 		Names of venvs to ignore. Will then get the name of the venv by ascending to the parent directory
 	:param bool ignore_venv:


### PR DESCRIPTION
This trivial whitespace-only commit fixes two diagnostic messages that pop up during generation of the documentation.
* Fix indentation
* Add blank line between function description and parameter list