### PR TITLE
Feature: add username_variable, password_variable, server_variable, port_variable to options to mail segment

### DIFF
--- a/powerline/segments/common/mail.py
+++ b/powerline/segments/common/mail.py
@@ -29,7 +29,7 @@ class EmailIMAPSegment(KwThreadedSegment):
 			password = os.environ[password_variable]
 		if server_variable:
 			server = os.environ[server_variable]
-		if port:
+		if port_variable:
 			port = os.environ[port_variable]
 
 		return _IMAPKey(username, password, server, port, folder, use_ssl)

--- a/powerline/segments/common/mail.py
+++ b/powerline/segments/common/mail.py
@@ -19,16 +19,16 @@ class EmailIMAPSegment(KwThreadedSegment):
 	interval = 60
 
 	@staticmethod
-	def key(username, password, server='imap.gmail.com', port=IMAP4_SSL_PORT, folder='INBOX', use_ssl=None, **kwargs):
+	def key(username='', password='', server='imap.gmail.com', username_variable='', password_variable='', server_variable='', port=IMAP4_SSL_PORT, folder='INBOX', use_ssl=None, **kwargs):
 		if use_ssl is None:
 			use_ssl = (port == IMAP4_SSL_PORT)
 		# catch if user set custom mail credential env variables
 		if username_variable:
-			username = os.environ.get(username_variable, None)
+			username = os.environ[username_variable]
 		if password_variable:
-			password = os.environ.get(password_variable, None)
+			password = os.environ[password_variable]
 		if server_variable:
-			server = os.enviorn.get(server_variable, server)
+			server = os.environ[server_variable]
 
 		return _IMAPKey(username, password, server, port, folder, use_ssl)
 

--- a/powerline/segments/common/mail.py
+++ b/powerline/segments/common/mail.py
@@ -19,7 +19,7 @@ class EmailIMAPSegment(KwThreadedSegment):
 	interval = 60
 
 	@staticmethod
-	def key(username='', password='', server='imap.gmail.com', username_variable='', password_variable='', server_variable='', port=IMAP4_SSL_PORT, folder='INBOX', use_ssl=None, **kwargs):
+	def key(username='', password='', server='imap.gmail.com', port=IMAP4_SSL_PORT, username_variable='', password_variable='', server_variable='', port_variable='', folder='INBOX', use_ssl=None, **kwargs):
 		if use_ssl is None:
 			use_ssl = (port == IMAP4_SSL_PORT)
 		# catch if user set custom mail credential env variables
@@ -29,6 +29,8 @@ class EmailIMAPSegment(KwThreadedSegment):
 			password = os.environ[password_variable]
 		if server_variable:
 			server = os.environ[server_variable]
+		if port:
+			port = os.environ[port_variable]
 
 		return _IMAPKey(username, password, server, port, folder, use_ssl)
 
@@ -72,14 +74,16 @@ email_imap_alert = with_docstring(EmailIMAPSegment(),
 	login password
 :param str server:
 	e-mail server
+:param int port:
+	e-mail server port
 :param str username_variable:
 	name of environment variable to check for login username
 :param str password_variable:
 	name of environment variable to check for login password
 :param str server_variable:
 	name of environment variable to check for email server
-:param int port:
-	e-mail server port
+:param str port_variable:
+	name of environment variable to check for email server port
 :param str folder:
 	folder to check for e-mails
 :param int max_msgs:

--- a/powerline/segments/common/mail.py
+++ b/powerline/segments/common/mail.py
@@ -19,7 +19,7 @@ class EmailIMAPSegment(KwThreadedSegment):
 	interval = 60
 
 	@staticmethod
-	def key(username, password, username_variable, password_variable, server='imap.gmail.com', port=IMAP4_SSL_PORT, folder='INBOX', use_ssl=None, **kwargs):
+	def key(username, password, server='imap.gmail.com', port=IMAP4_SSL_PORT, folder='INBOX', use_ssl=None, **kwargs):
 		if use_ssl is None:
 			use_ssl = (port == IMAP4_SSL_PORT)
 		# catch if user set custom mail credential env variables
@@ -27,6 +27,8 @@ class EmailIMAPSegment(KwThreadedSegment):
 			username = os.environ.get(username_variable, None)
 		if password_variable:
 			password = os.environ.get(password_variable, None)
+		if server_variable:
+			server = os.enviorn.get(server_variable, server)
 
 		return _IMAPKey(username, password, server, port, folder, use_ssl)
 
@@ -68,12 +70,14 @@ email_imap_alert = with_docstring(EmailIMAPSegment(),
 	login username
 :param str password:
 	login password
+:param str server:
+	e-mail server
 :param str username_variable:
 	name of environment variable to check for login username
 :param str password_variable:
 	name of environment variable to check for login password
-:param str server:
-	e-mail server
+:param str server_variable:
+	name of environment variable to check for email server
 :param int port:
 	e-mail server port
 :param str folder:

--- a/powerline/segments/common/mail.py
+++ b/powerline/segments/common/mail.py
@@ -1,6 +1,8 @@
 # vim:fileencoding=utf-8:noet
 from __future__ import (unicode_literals, division, absolute_import, print_function)
 
+import os
+
 import re
 
 from imaplib import IMAP4_SSL_PORT, IMAP4_SSL, IMAP4
@@ -17,9 +19,15 @@ class EmailIMAPSegment(KwThreadedSegment):
 	interval = 60
 
 	@staticmethod
-	def key(username, password, server='imap.gmail.com', port=IMAP4_SSL_PORT, folder='INBOX', use_ssl=None, **kwargs):
+	def key(username, password, username_variable, password_variable, server='imap.gmail.com', port=IMAP4_SSL_PORT, folder='INBOX', use_ssl=None, **kwargs):
 		if use_ssl is None:
 			use_ssl = (port == IMAP4_SSL_PORT)
+		# catch if user set custom mail credential env variables
+		if username_variable:
+			username = os.environ.get(username_variable, None)
+		if password_variable:
+			password = os.environ.get(password_variable, None)
+
 		return _IMAPKey(username, password, server, port, folder, use_ssl)
 
 	def compute_state(self, key):
@@ -60,6 +68,10 @@ email_imap_alert = with_docstring(EmailIMAPSegment(),
 	login username
 :param str password:
 	login password
+:param str username_variable:
+	name of environment variable to check for login username
+:param str password_variable:
+	name of environment variable to check for login password
 :param str server:
 	e-mail server
 :param int port:


### PR DESCRIPTION
This is a continuation of the proposal in #2224, but the base branch was `master` instead of `develop`, and I updated the feature branch name in the fork.

We also decided to add allowing users to specify the names of the shell environment variables they want to use, that way they can have different env variables for different segments.

Overall this adds 4 new parameters:

|  parameter              | description                |
|:-------------------:|:--------------------:|
| username_variable | string, name of env var to check for email username |
| password_variable | string, name of env var to check for email password |
| server_variable      | string, name of env var to check for email server    |
| port_variable         | string, name of env var to check for email server port    |

So a user could now create a segment like this:

```json
        {
            "function": "powerline.segments.common.mail.email_imap_alert",
            "args": {
                "username_variable": "MAIL_USER",
                "password_variable": "MAIL_PASS",
                "server_variable":   "MAIL_SERVER",
                "port_variable":     "MAIL_PORT",
                "use_ssl": false,
            }
        },
```

and then have those variables exported in BASH; example (this would let you use the protonmail-bridge):

```bash
export MAIL_USER="youruser@protonmail.com"
export MAIL_PASS="secret bridge password"
export MAIL_SERVER="127.0.0.1"
export MAIL_PORT=1143
```