### PR TITLE
Add link to installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ You should check out some of the Powerline derivatives. The most lightweight
 and feature-rich alternative is currently the `vim-airline 
 <https://github.com/vim-airline/vim-airline>`_ project.
 
+Installation
+-------------
+
+See in documentation here https://powerline.readthedocs.io/en/latest/installation.html
+
 Configuration
 -------------
 


### PR DESCRIPTION
Fix the issue that when you come back after a while to the readme, you start to search for 'install' on the page and there is no results, you have to spend time to find the link to the documentation in the description.