### PR TITLE
fix empty artist in dbus_player segment

### DIFF
--- a/powerline/segments/common/players.py
+++ b/powerline/segments/common/players.py
@@ -296,6 +296,8 @@ else:
 			title = out_u(title)
 		if artist:
 			artist = out_u(artist[0])
+		else:
+			artist = ""
 
 		length = info.get('mpris:length')
 		# avoid parsing `None` length values, that would


### PR DESCRIPTION
When the dbus-connected media player (eg, Supersonic) finishes playing music, the `artist` variable is shown in the segment as:

    dbus.Array([], signature=dbus.Signature('s'), variant_level=1)

instead of an empty string. This fixes the issue.