### PR TITLE
Update tmux.py to fix invalid < comparison between string and int

### DIFF
--- a/powerline/segments/tmux.py
+++ b/powerline/segments/tmux.py
@@ -19,4 +19,4 @@ def attached_clients(pl, minimum=1):
 	attached_clients_output = get_tmux_output(pl, 'list-clients', '-t', session_name)
 	attached_count = len(attached_clients_output.rstrip().split('\n'))
 
-	return None if attached_count < minimum else str(attached_count)
+	return None if attached_count < int(minimum) else str(attached_count)


### PR DESCRIPTION
Fix   
```
File "/usr/lib/python3.11/site-packages/powerline/segments/tmux.py", line 22, in attached_clients
    return None if attached_count < minimum else str(attached_count)
                   ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'int' and 'str'
```