### PR TITLE
Fix bug with parsing tmux version from next-<major>.<minor>

### DIFF
--- a/powerline/bindings/tmux/__init__.py
+++ b/powerline/bindings/tmux/__init__.py
@@ -81,5 +81,6 @@ def get_tmux_version(pl):
 	major, minor = version_string.split('.')
 	major = NON_DIGITS.subn('', major)[0]
 	suffix = DIGITS.subn('', minor)[0] or None
+	major = NON_DIGITS.subn('', major)[0]
 	minor = NON_DIGITS.subn('', minor)[0]
 	return TmuxVersionInfo(int(major), int(minor), suffix)


### PR DESCRIPTION
I recently ran some `dnf` upgrades on fedora and `powerline` stopped working with `tmux`. I traced the error back to the output from `powerline-config tmux setup`.

```
rrosenblum@localhost:~$ powerline-config tmux setup
Traceback (most recent call last):
  File "/usr/local/bin/powerline-config", line 22, in <module>
    args.function(pl, args)
  File "~/.local/lib/python3.12/site-packages/powerline/commands/config.py", line 15, in __call__
    self.function(*args, **kwargs)
  File "~/.local/lib/python3.12/site-packages/powerline/bindings/config.py", line 184, in tmux_setup
    tmux_version = get_tmux_version(pl)
                   ^^^^^^^^^^^^^^^^^^^^
  File "~/.local/lib/python3.12/site-packages/powerline/bindings/tmux/__init__.py", line 85, in get_tmux_version
    return TmuxVersionInfo(int(major), int(minor), suffix)
                           ^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'next-3'


rrosenblum@localhost:~$ tmux -V
tmux next-3.4
```

I tested this locally by modifying `~/.local/lib/python3.12/site-packages/powerline/bindings/tmux/__init__.py` in place with the same change in this MR. While I did see some similar issues listed in the past, I was not able to find an active issue or MR related to this. It seems like I'm running tmux version 3.3a so I'm not really sure why it is reporting as next-3.4