### PR TITLE
SSH_CLIENT got deprecated, use SSH_CONNECTION instead

### DIFF
--- a/powerline/segments/common/net.py
+++ b/powerline/segments/common/net.py
@@ -27,7 +27,7 @@ def hostname(pl, segment_info, only_if_ssh=False, exclude_domain=False):
 		== 'ee5bcdc6-b749-11e7-9456-50465d597777'
 	):
 		return 'hostname'
-	if only_if_ssh and not segment_info['environ'].get('SSH_CLIENT'):
+	if only_if_ssh and not segment_info['environ'].get('SSH_CONNECTION'):
 		return None
 	if exclude_domain:
 		return socket.gethostname().split('.')[0]


### PR DESCRIPTION
SSH_CLIENT was deprecated more than 2 decades ago. See here [0].

[0] https://github.com/openssh/openssh-portable/commit/f37e246