### PR TITLE
Fix compatibility with Python 3.13 and up

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.11, 3.12]
+        python-version: [3.8, 3.9, 3.11, 3.12, 3.13]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.11, 3.12, 3.13]
+        python-version: [3.8, 3.9, 3.11, 3.12, 3.13, 3.14]
 
     steps:
     - name: Checkout code

--- a/docs/source/develop/local-themes.rst
+++ b/docs/source/develop/local-themes.rst
@@ -10,7 +10,7 @@ prompt). Used themes are defined in :ref:`local_themes key
 Vim local themes
 ================
 
-Vim is the only available extension that has a wide variaty of options for local 
+Vim is the only available extension that has a wide variety of options for local 
 themes. It is the only extension where local theme key refers to a function as 
 described in :ref:`local_themes value documentation <config-ext-local_themes>`. 
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -19,7 +19,7 @@ After an update something stopped working
 Assuming powerline was working before update and stopped only after there are 
 two possible explanations:
 
-* You have more then one powerline installation (e.g. ``pip`` and ``Vundle`` 
+* You have more than one powerline installation (e.g. ``pip`` and ``Vundle`` 
   installations) and you have updated only one.
 * Update brought some bug to powerline.
 

--- a/powerline/__init__.py
+++ b/powerline/__init__.py
@@ -958,7 +958,7 @@ class Powerline(object):
 			shut down all threads. Set it to False unless you are exiting an
 			application.
 
-			If set to False this does nothing more then resolving reference
+			If set to False this does nothing more than resolving reference
 			cycle ``powerline → config_loader → bound methods → powerline`` by
 			unsubscribing from config_loader events.
 		'''

--- a/powerline/commands/daemon.py
+++ b/powerline/commands/daemon.py
@@ -16,9 +16,7 @@ def get_argparser(ArgumentParser=argparse.ArgumentParser):
 		     'Does not silence exceptions in any case.'
 	)
 	parser.add_argument('--socket', '-s', help='Specify socket which will be used for connecting to daemon.')
-	exclusive_group = parser.add_mutually_exclusive_group()
-	exclusive_group.add_argument('--kill', '-k', action='store_true', help='Kill an already running instance.')
-	replace_group = exclusive_group.add_argument_group()
-	replace_group.add_argument('--foreground', '-f', action='store_true', help='Run in the foreground (don’t daemonize).')
-	replace_group.add_argument('--replace', '-r', action='store_true', help='Replace an already running instance.')
+	parser.add_argument('--kill', '-k', action='store_true', help='Kill an already running instance.')
+	parser.add_argument('--foreground', '-f', action='store_true', help='Run in the foreground (don’t daemonize).')
+	parser.add_argument('--replace', '-r', action='store_true', help='Replace an already running instance.')
 	return parser

--- a/powerline/lib/unicode.py
+++ b/powerline/lib/unicode.py
@@ -85,7 +85,7 @@ def register_strwidth_error(strwidth):
 	needed settings) and emits new error handling method name.
 
 	:param function strwidth:
-		Function that computs string width measured in display cells the string 
+		Function that computes string width measured in display cells the string 
 		occupies when displayed.
 
 	:return: New error handling method name.

--- a/powerline/lib/vcs/git.py
+++ b/powerline/lib/vcs/git.py
@@ -112,7 +112,7 @@ try:
 		def do_status(self, directory, path):
 			if path:
 				try:
-					status = git.Repository(directory).status_file(path)
+					status = git.Repository(directory).status_file(str(path))
 				except (KeyError, ValueError):
 					return None
 

--- a/powerline/lint/markedjson/scanner.py
+++ b/powerline/lint/markedjson/scanner.py
@@ -423,7 +423,7 @@ class Scanner:
 						if self.peek(k) not in hexdigits:
 							raise ScannerError(
 								'while scanning a double-quoted scalar', start_mark,
-								'expected escape sequence of %d hexdecimal numbers, but found %r' % (
+								'expected escape sequence of %d hexadecimal numbers, but found %r' % (
 									length, self.peek(k)),
 								self.get_mark()
 							)

--- a/powerline/lint/spec.py
+++ b/powerline/lint/spec.py
@@ -46,7 +46,7 @@ class Spec(object):
 
 	.. note::
 		In ``check_`` and ``match`` methods specifications are identified by 
-		their indexes for the purpose of simplyfying :py:meth:`Spec.copy` 
+		their indexes for the purpose of simplifying :py:meth:`Spec.copy` 
 		method.
 
 	Some common parameters:

--- a/powerline/segments/i3wm.py
+++ b/powerline/segments/i3wm.py
@@ -247,7 +247,7 @@ def mode(pl, segment_info, names={'default': None}):
 		Specifies the string to show for various modes.
 		Use ``null`` to hide a mode (``default`` is hidden by default).
 
-	Highligh groups used: ``mode``
+	Highlight groups used: ``mode``
 	'''
 	mode = segment_info['mode']
 	if mode in names:

--- a/powerline/segments/vim/__init__.py
+++ b/powerline/segments/vim/__init__.py
@@ -127,7 +127,7 @@ def visual_range(pl, segment_info, CTRL_V_text='{rows} x {vcols}', v_text_onelin
 		selection occupies only one line.
 	:param str v_text_multiline:
 		Text to display when in charaterwise visual or select mode, assuming
-		selection occupies more then one line.
+		selection occupies more than one line.
 	:param str V_text:
 		Text to display when in linewise visual or select mode.
 

--- a/scripts/powerline-daemon
+++ b/scripts/powerline-daemon
@@ -268,7 +268,7 @@ def shutdown(sock, read_sockets, write_sockets, state):
 	#. Notifies segments based on 
 	  :py:class:`powerline.lib.threaded.ThreadedSegment` and WM-specific 
 	  threads that daemon is shutting down.
-	#. Waits for threads to finish, but no more then 2 seconds total.
+	#. Waits for threads to finish, but no more than 2 seconds total.
 	#. Waits so that total execution time of this function is 2 seconds in order 
 	   to allow ThreadedSegments to finish.
 	'''

--- a/tests/test_in_vterm/test_shells.py
+++ b/tests/test_in_vterm/test_shells.py
@@ -7,7 +7,6 @@ import sys
 
 from time import sleep
 from subprocess import check_call
-from glob import glob1
 from traceback import print_exc
 
 from argparse import ArgumentParser

--- a/tests/test_in_vterm/test_tmux.py
+++ b/tests/test_in_vterm/test_tmux.py
@@ -8,7 +8,7 @@ import json
 
 from time import sleep
 from subprocess import check_call
-from glob import glob1
+from glob import glob
 from traceback import print_exc
 
 from powerline.lib.dict import updated
@@ -24,7 +24,7 @@ TEST_ROOT = os.path.abspath(os.environ['TEST_ROOT'])
 
 
 def tmux_logs_iter(test_dir):
-	for tail in glob1(test_dir, '*.log'):
+	for tail in glob('*.log', root_dir=test_dir):
 		yield os.path.join(test_dir, tail)
 
 

--- a/tests/test_in_vterm/test_vim.py
+++ b/tests/test_in_vterm/test_vim.py
@@ -7,7 +7,6 @@ import sys
 
 from time import sleep
 from subprocess import check_call
-from glob import glob1
 from traceback import print_exc
 
 from powerline.lib.dict import updated

--- a/tests/test_python/test_cmdline.py
+++ b/tests/test_python/test_cmdline.py
@@ -52,7 +52,7 @@ class TestParser(TestCase):
 			]:
 				self.assertRaises(SystemExit, parser.parse_args, raising_args)
 				self.assertFalse(out.getvalue())
-				self.assertRegexpMatches(err.getvalue(), raising_reg)
+				self.assertRegex(err.getvalue(), raising_reg)
 				flush()
 
 	def test_main_normal(self):

--- a/tests/test_shells/test.sh
+++ b/tests/test_shells/test.sh
@@ -217,7 +217,7 @@ IPYTHON_PYTHON=ipython
 
 if test -z "$POWERLINE_RC_EXE" ; then
 	if which rc-status >/dev/null ; then
-		# On Gentoo `rc` executable is from OpenRC. Thus app-shells/rc instals 
+		# On Gentoo `rc` executable is from OpenRC. Thus app-shells/rc installs 
 		# `rcsh` executable.
 		POWERLINE_RC_EXE=rcsh
 	else


### PR DESCRIPTION
* Fix a `TypeError` in the Vim statusline that occurs with Python 3.13.
* Fix a `ValueError` in `powerline-daemon` that will occur with Python 3.14 - nesting argument groups has been removed (https://bugzilla.redhat.com/show_bug.cgi?id=2336943).
* While at it, fix a bunch of typos.
* Fix the CI pipeline.