### PR TITLE
powerline-setup.fish: Fix line 26 throwing a source error in Fish 4.7.1

### DIFF
--- a/powerline/bindings/fish/powerline-setup.fish
+++ b/powerline/bindings/fish/powerline-setup.fish
@@ -23,7 +23,7 @@ function powerline-setup
 			set -g POWERLINE_COMMAND (env $POWERLINE_CONFIG_COMMAND shell command)
 		end
 		function _powerline_set_default_mode --on-variable fish_key_bindings
-			if test $fish_key_bindings != fish_vi_key_bindings
+			if test "$fish_key_bindings" != fish_vi_key_bindings
 				set -g _POWERLINE_DEFAULT_MODE default
 			else
 				set -g -e _POWERLINE_DEFAULT_MODE


### PR DESCRIPTION
Fix Fish 4.7.1 complaining about a missing test argument because of missing variable quotes